### PR TITLE
Harden ORA-01720 grant dependencies and fatal reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 > 核心理念：一次转储、本地对比、脚本审计优先
 
 ## 近期更新（0.9.8.9）
+- VIEW 授权依赖补强：对 `ORA-01720` 敏感的 VIEW 授权链，程序会继续生成 `view_prereq_grants/`；`run_fixup` 在执行 `view_post_grants/` 命中 `ORA-01720` 时，也会按失败语句里的真实 privilege 回补底层 `WITH GRANT OPTION` 再重试。
 - 黑名单表重纳管增强：`blacklist_target_existing_policy=rehydrate_if_present` 已进入正式版本；当目标端已存在人工改造后的承接表时，可恢复后续 compare/fixup，并自动保护黑名单改造列不被写回 Oracle 原始语义。
 - 触发器边界更准确：`INSTEAD OF ... ON VIEW` 触发器已纳入正常 compare/fixup；`DATABASE/SCHEMA` 级事件触发器继续保留为人工处理。
 - Oracle 派生表降噪补齐：`RUPD$_*`、`SNAP$_*` 与既有 `MLOG$_*` 一样按系统工件从 compare/fixup 中排除。
@@ -260,6 +261,7 @@ python3 run_fixup.py --smart-order --recompile --allow-table-create
 - `main_reports/run_<ts>/column_identity_detail_<ts>.txt`：现有列 identity 差异明细（含 `ALWAYS / BY DEFAULT / BY DEFAULT ON NULL` 模式差异；首版为 review-first）
 - `main_reports/run_<ts>/column_identity_option_detail_<ts>.txt`：现有列 identity 细项差异明细（首批覆盖 `START WITH / INCREMENT BY / CACHE`；仅在 identity 模式一致时比较，首版为 review-first）
 - `main_reports/run_<ts>/identity_sequence_grant_detail_<ts>.txt`：identity 表跨 schema 授权明细（目标端 `ISEQ$$_...` 定位结果、缺失 grant、人工确认项）
+- `main_reports/run_<ts>/fatal_error_matrix_<ts>.txt`：fatal 场景矩阵（哪些错误会直接终止、当前是否相关、如何修复）
 - `main_reports/run_<ts>/column_default_on_null_detail_<ts>.txt`：现有列 `DEFAULT ON NULL` 语义差异明细（双向 compare；首版为 review-first）
 - `main_reports/run_<ts>/column_default_detail_<ts>.txt`：现有列默认值差异明细（仅列级语义，不等同 `DEFAULT ON NULL`）
 - `main_reports/run_<ts>/dependency_detail_<ts>.txt`：依赖差异明细（report_detail_mode=split）
@@ -288,6 +290,7 @@ python3 run_fixup.py --smart-order --recompile --allow-table-create
 - 如果源端触发器是 `DATABASE/SCHEMA` 级事件触发器（例如 `BEFORE DROP ON DATABASE`），程序不会再静默漏掉；会输出到 `triggers_non_table_detail_<ts>.txt`，并在 `manual_actions_required_<ts>.txt` 中显式提醒。`INSTEAD OF ... ON VIEW` 会按普通受管触发器参与 compare/fixup。
 - 当 `source_object_scope_mode=remap_root_closure` 且配置了 `trigger_list` 时，`trigger_list` 支持填写源端名或 remap 后目标名；若条目无法在源端或显式 remap 规则中解析，只会写入 `source_scope_detail_<ts>.txt` / `trigger_status_report.txt`，不会再中止整轮运行。
 - 在 scoped trigger 场景下，如果触发器依赖的目标 TABLE/VIEW 尚未创建，首轮只会生成依赖对象脚本；TRIGGER 自身会在 `fixup_skip_summary_<ts>.txt` 中标记为 `base_table_missing` 或同类跳过原因，待依赖补齐后 rerun 再生成 trigger DDL。
+- 对 `view_post_grants/` 中的 `GRANT SELECT/INSERT/UPDATE/DELETE ON <view> TO <grantee>`，若目标端因缺少底层 `WITH GRANT OPTION` 命中 `ORA-01720`，`run_fixup` 会按失败语句里的真实 privilege 自动补底层依赖授权后重试，不再只把它记成普通权限不足。
 - 触发器中的 `PRAGMA AUTONOMOUS_TRANSACTION` 现在会保留，不再被清洗掉。
 
 ## DDL 清理治理

--- a/docs/TECHNICAL_SPECIFICATION.md
+++ b/docs/TECHNICAL_SPECIFICATION.md
@@ -186,6 +186,7 @@
 - 视图权限拆分：依赖对象授权输出到 `view_prereq_grants/`，视图自身授权输出到 `view_post_grants/`
 - 视图链路要求 `WITH GRANT OPTION` 的场景会单独标注缺失
 - 依赖推导不再对 PUBLIC 生成授权，仅保留源端显式 PUBLIC 授权
+- 对 `view_post_grants/` 中失败的 `GRANT ... ON <view>`，`run_fixup` 会从失败语句中提取真实 privilege（如 `UPDATE`），再按 VIEW 依赖链补底层对象授权；不再把所有此类失败统一降级成 `SELECT`
 - 对 identity 表的跨 schema 授权，系统会额外定位目标端底层 `ISEQ$$_...`：当源端存在 `INSERT` 授权而目标端缺少对应 sequence `SELECT` 时，会输出 `identity_sequence_grant_detail_<ts>.txt`，并把 `GRANT SELECT ON <ISEQ$$_...>` 注入 `grants_miss/`
 - identity sequence 定位优先使用目标端 `DBA_OBJECTS.CREATED` 与 `DBA_SEQUENCES` 的同秒候选收敛；若候选不唯一且 identity 选项无法进一步收敛，则保持 report-only，不盲猜 sequence 名
 - 输出 `grants_miss/` 与 `grants_all/`
@@ -216,6 +217,15 @@
 - `fixup_scripts/view_post_grants/`
 - `fixup_scripts/compile/`
 - `fixup_scripts/grants_miss/`
+
+### 7.4 Fatal 场景矩阵
+- 每轮报告会额外输出 `fatal_error_matrix_<ts>.txt`
+- 该矩阵不改变程序行为，只集中列出：
+  - fatal 分类
+  - 触发条件
+  - 默认行为
+  - 当前 run 是否相关
+  - 修复建议
 
 ---
 

--- a/readme_config.txt
+++ b/readme_config.txt
@@ -66,6 +66,7 @@
   说明：若存在不支持的约束（如 DEFERRABLE / CHECK SYS_CONTEXT / 自引用外键），会额外输出 constraints_unsupported_detail_<timestamp>.txt（不受 report_detail_mode 影响）。
   说明：若存在“触发器挂在临时表”场景，会额外输出 triggers_temp_table_unsupported_detail_<timestamp>.txt（不受 report_detail_mode 影响）；
   对应 DDL 仅输出到 `fixup_scripts/unsupported/trigger/`，用于人工改造参考，不进入普通 `trigger/`。
+  说明：split/full 模式下还会额外输出 `fatal_error_matrix_<ts>.txt`，集中列出当前程序仍会直接终止运行的 fatal 场景、当前是否相关，以及修复建议。
 - report_to_db：是否将报告存储到 OceanBase（obclient 方式）。默认：true。
   说明：开启后仍会保留本地文本报告，写库失败时是否中断由 report_db_fail_abort 控制。
   说明：写库采用发布门禁；DIFF_REPORT_SUMMARY.WRITE_STATUS=READY 才表示可用于正式排查（WRITING/FAILED 为未完成或失败）。
@@ -295,6 +296,7 @@
   仍需先按运维基线补齐 `OB_CATALOG_ROLE` 的对象授权模型。
 - fixup_auto_grant：run_fixup 自动补权限。默认：true。
   说明：基于 dependency_chains 与 VIEWs_chain 预判依赖授权，执行前自动应用 grants_miss/grants_all 中的授权。
+  说明：当 `view_post_grants/` 中的视图授权命中 `ORA-01720` 时，执行器会按失败语句里的真实 privilege（SELECT/INSERT/UPDATE/DELETE）补底层依赖对象授权，而不是一律退化成 `SELECT`。
   说明：run_fixup 默认跳过 `fixup_scripts/grants_deferred/`，对象补齐后需显式执行该目录。
 - fixup_auto_grant_types：自动补权限对象类型（逗号分隔）。默认：
   VIEW, MATERIALIZED VIEW, SYNONYM, PROCEDURE, FUNCTION, PACKAGE, PACKAGE BODY, TYPE, TYPE BODY。

--- a/run_fixup.py
+++ b/run_fixup.py
@@ -2525,6 +2525,29 @@ def infer_error_object(statement: str, relative_path: Path) -> str:
     return "-"
 
 
+def infer_permission_retry_target(
+    statement: str,
+    relative_path: Path,
+) -> Optional[Tuple[str, str, Set[str]]]:
+    parsed = parse_grant_statement(statement)
+    if not parsed:
+        return None
+    grant_type, privileges, object_full, _grantees = parsed
+    if grant_type != "OBJECT" or not object_full:
+        return None
+    dir_name = (relative_path.parent.name or "").lower()
+    if dir_name == "view_post_grants":
+        obj_type = "VIEW"
+    elif dir_name == "view_prereq_grants":
+        obj_type = "VIEW"
+    else:
+        return None
+    privilege_set = {(item or "").upper() for item in (privileges or ()) if (item or "").strip()}
+    if not privilege_set:
+        return None
+    return normalize_full_name(object_full), obj_type, privilege_set
+
+
 def grant_statement_has_option(statement: str) -> bool:
     if not statement:
         return False
@@ -2537,7 +2560,12 @@ def format_privilege_label(privilege: str, grant_option: bool) -> str:
     return f"{privilege} WITH GRANT OPTION"
 
 
-def requires_grant_option(grantee: str, target_full: str, target_type: str) -> bool:
+def requires_grant_option(
+    grantee: str,
+    target_full: str,
+    target_type: str,
+    dependent_type: Optional[str] = None,
+) -> bool:
     if not grantee or not target_full or not target_type:
         return False
     target_schema, _ = split_full_name(target_full)
@@ -2545,7 +2573,11 @@ def requires_grant_option(grantee: str, target_full: str, target_type: str) -> b
         return False
     if target_schema.upper() == grantee.upper():
         return False
-    return target_type.upper() in GRANT_OPTION_TYPES
+    dep_type_u = (dependent_type or "").upper()
+    target_type_u = target_type.upper()
+    if dep_type_u in {"VIEW", "MATERIALIZED VIEW"} and target_type_u in {"TABLE", "VIEW", "MATERIALIZED VIEW"}:
+        return True
+    return target_type_u in GRANT_OPTION_TYPES
 
 
 def parse_chain_node(token: str) -> Optional[Tuple[str, str]]:
@@ -2937,7 +2969,8 @@ def init_auto_grant_context(
 def build_auto_grant_plan_for_object(
     ctx: AutoGrantContext,
     obj_full: str,
-    obj_type: str
+    obj_type: str,
+    required_privileges_override: Optional[Set[str]] = None,
 ) -> Tuple[List[str], List[str], bool]:
     obj_full_u = normalize_full_name(obj_full)
     obj_type_u = normalize_object_type(obj_type)
@@ -2953,35 +2986,42 @@ def build_auto_grant_plan_for_object(
     for ref_full, ref_type in sorted(deps):
         ref_full_u = normalize_full_name(ref_full)
         ref_type_u = normalize_object_type(ref_type)
-        required_priv = GRANT_PRIVILEGE_BY_TYPE.get(ref_type_u)
-        if not required_priv:
+        required_privs: List[str] = []
+        if required_privileges_override and obj_type_u in {"VIEW", "MATERIALIZED VIEW"} and ref_type_u in {"TABLE", "VIEW", "MATERIALIZED VIEW"}:
+            required_privs = sorted({(item or "").upper() for item in required_privileges_override if (item or "").strip()})
+        else:
+            required_priv = GRANT_PRIVILEGE_BY_TYPE.get(ref_type_u)
+            if required_priv:
+                required_privs = [required_priv]
+        if not required_privs:
             continue
         ref_schema, _ = split_full_name(ref_full_u)
         if not ref_schema or ref_schema.upper() == grantee_schema.upper():
             continue
-        require_option = requires_grant_option(grantee_schema, ref_full_u, ref_type_u)
-        blocked = plan_object_grant_for_dependency(
-            grantee_schema,
-            ref_full_u,
-            ref_type_u,
-            required_priv,
-            require_option,
-            ctx.settings.fallback,
-            ctx.obclient_cmd,
-            ctx.timeout,
-            ctx.grant_index_miss,
-            ctx.grant_index_all,
-            ctx.roles_cache,
-            ctx.tab_privs_cache,
-            ctx.tab_privs_grantable_cache,
-            ctx.sys_privs_cache,
-            ctx.planned_statements,
-            ctx.planned_object_privs,
-            ctx.planned_object_privs_with_option,
-            ctx.planned_sys_privs,
-            plan_lines,
-            sql_lines
-        ) or blocked
+        require_option = requires_grant_option(grantee_schema, ref_full_u, ref_type_u, obj_type_u)
+        for required_priv in required_privs:
+            blocked = plan_object_grant_for_dependency(
+                grantee_schema,
+                ref_full_u,
+                ref_type_u,
+                required_priv,
+                require_option,
+                ctx.settings.fallback,
+                ctx.obclient_cmd,
+                ctx.timeout,
+                ctx.grant_index_miss,
+                ctx.grant_index_all,
+                ctx.roles_cache,
+                ctx.tab_privs_cache,
+                ctx.tab_privs_grantable_cache,
+                ctx.sys_privs_cache,
+                ctx.planned_statements,
+                ctx.planned_object_privs,
+                ctx.planned_object_privs_with_option,
+                ctx.planned_sys_privs,
+                plan_lines,
+                sql_lines
+            ) or blocked
     return plan_lines, sql_lines, blocked
 
 
@@ -2989,7 +3029,8 @@ def execute_auto_grant_for_object(
     ctx: AutoGrantContext,
     obj_full: str,
     obj_type: str,
-    label: str
+    label: str,
+    required_privileges_override: Optional[Set[str]] = None,
 ) -> Tuple[int, bool]:
     if not ctx.settings.enabled:
         return 0, False
@@ -3003,7 +3044,12 @@ def execute_auto_grant_for_object(
         ctx.stats.skipped += 1
         log.info("%s [AUTO-GRANT] %s(%s) 已阻断，跳过重复规划。", label, obj_full_u, obj_type_u)
         return 0, True
-    plan_lines, sql_lines, blocked = build_auto_grant_plan_for_object(ctx, obj_full_u, obj_type_u)
+    plan_lines, sql_lines, blocked = build_auto_grant_plan_for_object(
+        ctx,
+        obj_full_u,
+        obj_type_u,
+        required_privileges_override=required_privileges_override,
+    )
     if blocked:
         ctx.stats.blocked += 1
         if not sql_lines:
@@ -3510,7 +3556,7 @@ def build_view_chain_plan(
                 plan_lines.append(f"BLOCK: 无法解析 grantee for {dep_full}")
                 blocked = True
                 continue
-            require_option = requires_grant_option(dep_schema, target_full, target_type)
+            require_option = requires_grant_option(dep_schema, target_full, target_type, dep_type)
             if require_option and target_type.upper() in GRANT_OPTION_TYPES:
                 blocked = ensure_view_owner_grant_option(
                     target_full,
@@ -4496,6 +4542,28 @@ def parse_grant_statement(statement: str) -> Optional[Tuple[str, Tuple[str, ...]
             return None
         return "SYSTEM", tuple(privs), None, grantees
     return None
+
+
+def infer_required_privileges_from_failed_statement(
+    statement: str,
+    object_full: str,
+    object_type: str,
+) -> Optional[Set[str]]:
+    parsed = parse_grant_statement(statement)
+    if not parsed:
+        return None
+    grant_type, privileges, parsed_object_full, _grantees = parsed
+    if grant_type != "OBJECT":
+        return None
+    parsed_object_u = normalize_full_name(parsed_object_full or "")
+    object_full_u = normalize_full_name(object_full or "")
+    if not parsed_object_u or not object_full_u or parsed_object_u != object_full_u:
+        return None
+    object_type_u = normalize_object_type(object_type)
+    if object_type_u not in {"VIEW", "MATERIALIZED VIEW"}:
+        return None
+    privilege_set = {(item or "").upper() for item in (privileges or ()) if (item or "").strip()}
+    return privilege_set or None
 
 
 def select_dependency_script(
@@ -5519,6 +5587,38 @@ def run_single_fixup(
                 state_ledger=state_ledger
             )
             error_truncated = error_truncated or truncated
+            if result.status == "FAILED":
+                first_error = summary.failures[0].error if summary.failures else result.message
+                error_type = classify_sql_error(first_error)
+                retry_target = None
+                if summary.failures:
+                    retry_target = infer_permission_retry_target(summary.failures[0].statement, relative_path)
+                if auto_grant_ctx and error_type == FailureType.PERMISSION_DENIED and retry_target:
+                    retry_full, retry_type, retry_privs = retry_target
+                    applied, _blocked = execute_auto_grant_for_object(
+                        auto_grant_ctx,
+                        retry_full,
+                        retry_type,
+                        f"{label} (grant)",
+                        required_privileges_override=retry_privs,
+                    )
+                    if applied > 0:
+                        retry_result, retry_summary, _removed2, _kept2, truncated2 = execute_grant_file_with_prune(
+                            obclient_cmd,
+                            sql_path,
+                            repo_root,
+                            done_dir,
+                            ob_timeout,
+                            layer,
+                            f"{label} (retry)",
+                            error_entries,
+                            DEFAULT_ERROR_REPORT_LIMIT,
+                            max_sql_file_bytes,
+                            state_ledger=state_ledger
+                        )
+                        error_truncated = error_truncated or truncated2
+                        results.append(retry_result)
+                        continue
             results.append(result)
         else:
             obj_type = DIR_OBJECT_TYPE_MAP.get(sql_path.parent.name.lower())
@@ -5564,6 +5664,13 @@ def run_single_fixup(
 
             first_error = summary.failures[0].error if summary.failures else result.message
             error_type = classify_sql_error(first_error)
+            required_priv_override = None
+            if summary.failures and obj_full and obj_type:
+                required_priv_override = infer_required_privileges_from_failed_statement(
+                    summary.failures[0].statement,
+                    obj_full,
+                    obj_type,
+                )
             handled = False
             if (
                 auto_grant_ctx
@@ -5575,7 +5682,8 @@ def run_single_fixup(
                     auto_grant_ctx,
                     obj_full,
                     obj_type,
-                    f"{label} (grant)"
+                    f"{label} (grant)",
+                    required_privileges_override=required_priv_override,
                 )
                 handled = applied > 0
 
@@ -6227,6 +6335,38 @@ def run_iterative_fixup(
                     state_ledger=state_ledger
                 )
                 error_truncated = error_truncated or truncated
+                if result.status == "FAILED":
+                    first_error = summary.failures[0].error if summary.failures else result.message
+                    error_type = classify_sql_error(first_error)
+                    retry_target = None
+                    if summary.failures:
+                        retry_target = infer_permission_retry_target(summary.failures[0].statement, relative_path)
+                    if auto_grant_ctx and error_type == FailureType.PERMISSION_DENIED and retry_target:
+                        retry_full, retry_type, retry_privs = retry_target
+                        applied, _blocked = execute_auto_grant_for_object(
+                            auto_grant_ctx,
+                            retry_full,
+                            retry_type,
+                            f"{label} (grant)",
+                            required_privileges_override=retry_privs,
+                        )
+                        if applied > 0:
+                            retry_result, retry_summary, _removed2, _kept2, truncated2 = execute_grant_file_with_prune(
+                                obclient_cmd,
+                                sql_path,
+                                repo_root,
+                                done_dir,
+                                ob_timeout,
+                                layer,
+                                f"{label} (retry)",
+                                error_entries,
+                                DEFAULT_ERROR_REPORT_LIMIT,
+                                current_max_sql_file_bytes,
+                                state_ledger=state_ledger
+                            )
+                            error_truncated = error_truncated or truncated2
+                            round_results.append(retry_result)
+                            continue
                 round_results.append(result)
                 continue
 
@@ -6325,12 +6465,20 @@ def run_iterative_fixup(
                         log.warning("%s %s -> 缺失对象未解析", label, relative_path)
 
             if error_type == FailureType.PERMISSION_DENIED:
+                required_priv_override = None
+                if summary.failures and obj_full and obj_type:
+                    required_priv_override = infer_required_privileges_from_failed_statement(
+                        summary.failures[0].statement,
+                        obj_full,
+                        obj_type,
+                    )
                 if auto_grant_ctx and obj_full and obj_type:
                     applied, _blocked = execute_auto_grant_for_object(
                         auto_grant_ctx,
                         obj_full,
                         obj_type,
-                        f"{label} (grant)"
+                        f"{label} (grant)",
+                        required_privileges_override=required_priv_override,
                     )
                     handled = applied > 0
                 else:

--- a/schema_diff_reconciler.py
+++ b/schema_diff_reconciler.py
@@ -1321,6 +1321,14 @@ class IdentitySequenceGrantDetailRow(NamedTuple):
     action: str
 
 
+class FatalErrorMatrixRow(NamedTuple):
+    category: str
+    trigger_condition: str
+    default_behavior: str
+    currently_relevant: str
+    remediation: str
+
+
 @dataclass(frozen=True)
 class GrantCapabilityDecision:
     support_status: str
@@ -39390,6 +39398,8 @@ def _infer_report_index_meta(path: Path) -> Tuple[str, str]:
         return "DETAIL", "目标端额外授权明细"
     if name.startswith("identity_sequence_grant_detail_"):
         return "DETAIL", "identity sequence 跨 schema 授权明细"
+    if name.startswith("fatal_error_matrix_"):
+        return "DETAIL", "fatal error 场景矩阵"
     if name.startswith("manual_actions_required_"):
         return "DETAIL", "人工处理/确认统一清单"
     if name.startswith("fixup_skip_summary_"):
@@ -42396,6 +42406,147 @@ def export_identity_sequence_grant_detail(
     return write_pipe_report("identity sequence 跨 schema 授权明细", header_fields, data_rows, output_path)
 
 
+def build_fatal_error_matrix_rows(settings: Optional[Dict]) -> List[FatalErrorMatrixRow]:
+    settings = settings or {}
+    enabled_extra_types = {str(t).upper() for t in (settings.get("enabled_extra_types") or set()) if str(t).strip()}
+    source_scope_mode = normalize_source_object_scope_mode(settings.get("source_object_scope_mode", "full_source"))
+    object_created_before_enabled = bool(settings.get("object_created_before_enabled"))
+    missing_created_policy = normalize_object_created_missing_policy(
+        settings.get("object_created_before_missing_created_policy", "strict")
+    )
+    generate_fixup_enabled = parse_bool_flag(settings.get("generate_fixup", "true"), True)
+    report_to_db = parse_bool_flag(settings.get("report_to_db", "true"), True)
+    report_db_fail_abort = parse_bool_flag(settings.get("report_db_fail_abort", "false"), False)
+    hot_reload_fail_policy = normalize_config_hot_reload_fail_policy(
+        settings.get("config_hot_reload_fail_policy", "keep_last_good")
+    )
+    case_mode = (settings.get("case_sensitive_identifier_mode", "warn") or "warn").strip().lower()
+    trigger_list_path = str(settings.get("trigger_list", "") or "").strip()
+
+    rows = [
+        FatalErrorMatrixRow(
+            category="CONFIG",
+            trigger_condition="config.ini 缺失/不可读、source_schemas 为空、核心配置非法",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES",
+            remediation="修正配置文件路径、补齐必填项并重新运行。",
+        ),
+        FatalErrorMatrixRow(
+            category="ORACLE_CLIENT",
+            trigger_condition="oracle_client_lib_dir 缺失/路径不存在/Thick Mode 初始化失败",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES",
+            remediation="补齐 oracle_client_lib_dir，检查 Instant Client 与 LD_LIBRARY_PATH。",
+        ),
+        FatalErrorMatrixRow(
+            category="OBCLIENT_SECURITY",
+            trigger_condition="obclient 缺失，或当前 obclient 不支持安全凭据参数",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES",
+            remediation="修正 obclient 路径，或升级到支持安全凭据参数的 obclient。",
+        ),
+        FatalErrorMatrixRow(
+            category="DBCAT_RUNTIME",
+            trigger_condition="generate_fixup=true 且 dbcat_bin/JAVA_HOME 不可用，或 dbcat 导出失败/超时",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES" if generate_fixup_enabled else "NO",
+            remediation="修正 dbcat_bin、JAVA_HOME、dbcat_from/dbcat_to，并检查 Oracle 连通性。",
+        ),
+        FatalErrorMatrixRow(
+            category="ORACLE_METADATA",
+            trigger_condition="Oracle 源对象列表、核心元数据、依赖或 CREATED 时间加载失败",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES",
+            remediation="检查 Oracle 连通性、账号权限与 DBA_* 字典访问能力。",
+        ),
+        FatalErrorMatrixRow(
+            category="OB_METADATA",
+            trigger_condition="OB 侧核心 DBA_* 字典（OBJECTS/TAB_COLUMNS/INDEXES/CONSTRAINTS/DEPENDENCIES/SEQUENCES）无法读取",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES",
+            remediation="检查 OB 连通性、账号权限与目标租户 Oracle 兼容字典可用性。",
+        ),
+        FatalErrorMatrixRow(
+            category="CUTOFF_STRICT",
+            trigger_condition="object_created_before 已启用，且 strict 策略下存在对象缺少 CREATED",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES" if object_created_before_enabled and missing_created_policy == "strict" else "NO",
+            remediation="改用 include_missing/exclude_missing，或先补齐 CREATED 可见性。",
+        ),
+        FatalErrorMatrixRow(
+            category="SCOPED_TRIGGER_LIST",
+            trigger_condition="remap_root_closure + trigger_list，但未启用 TRIGGER 检查、trigger_list 读失败、或存在非法条目",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES" if source_scope_mode == "remap_root_closure" and bool(trigger_list_path) else "NO",
+            remediation="启用 check_extra_types=TRIGGER，并修正 trigger_list 文件格式/路径。",
+        ),
+        FatalErrorMatrixRow(
+            category="SCOPED_ROOTS",
+            trigger_condition="remap_root_closure 下 remap_file 中没有可用的 TABLE/VIEW roots",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES" if source_scope_mode == "remap_root_closure" else "NO",
+            remediation="在 remap_file 中至少提供一个有效 TABLE/VIEW 根对象。",
+        ),
+        FatalErrorMatrixRow(
+            category="CASE_SENSITIVE_ABORT",
+            trigger_condition="case_sensitive_identifier_mode=abort 且发现双引号大小写敏感对象",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES" if case_mode == "abort" else "NO",
+            remediation="改用 warn/strict_fixup，或先专项处理大小写敏感对象。",
+        ),
+        FatalErrorMatrixRow(
+            category="FIXUP_PATH_SAFETY",
+            trigger_condition="fixup_dir 在配置目录外且未显式允许",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES" if generate_fixup_enabled else "NO",
+            remediation="显式开启 fixup_dir_allow_outside_repo，或把 fixup_dir 收回项目/配置目录内。",
+        ),
+        FatalErrorMatrixRow(
+            category="REPORT_DB",
+            trigger_condition="report_to_db=true 且写库失败后 db_ok=false（当前主流程会中止）",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES" if report_to_db and report_db_fail_abort else "NO",
+            remediation="先修复 report_db 连接/权限/表结构问题，或临时关闭 fail_abort。",
+        ),
+        FatalErrorMatrixRow(
+            category="HOT_RELOAD_ABORT",
+            trigger_condition="热加载配置解析失败且 fail_policy=abort",
+            default_behavior="FATAL_ABORT",
+            currently_relevant="YES" if hot_reload_fail_policy == "abort" else "NO",
+            remediation="改用 keep_last_good，或先修正热加载涉及的配置文件内容。",
+        ),
+    ]
+    return rows
+
+
+def export_fatal_error_matrix(
+    rows: List[FatalErrorMatrixRow],
+    report_dir: Path,
+    report_timestamp: Optional[str]
+) -> Optional[Path]:
+    if not report_dir or not report_timestamp or not rows:
+        return None
+    output_path = Path(report_dir) / f"fatal_error_matrix_{report_timestamp}.txt"
+    header_fields = [
+        "CATEGORY",
+        "TRIGGER_CONDITION",
+        "DEFAULT_BEHAVIOR",
+        "CURRENTLY_RELEVANT",
+        "REMEDIATION",
+    ]
+    data_rows = [
+        [
+            row.category,
+            row.trigger_condition,
+            row.default_behavior,
+            row.currently_relevant,
+            row.remediation,
+        ]
+        for row in rows
+    ]
+    return write_pipe_report("Fatal error 场景矩阵", header_fields, data_rows, output_path)
+
+
 OPERATOR_ACTION_PRIORITY_ORDER = {
     "BLOCKER": 0,
     "PREREQ": 1,
@@ -44701,6 +44852,8 @@ def _infer_report_artifact_type(rel_path: str) -> str:
         return "ORACLE_PRIVILEGE_FAMILY_DETAIL"
     if name.startswith("identity_sequence_grant_detail_"):
         return "IDENTITY_SEQUENCE_GRANT_DETAIL"
+    if name.startswith("fatal_error_matrix_"):
+        return "FATAL_ERROR_MATRIX"
     if name.startswith("manual_actions_required_"):
         return "MANUAL_ACTION_REQUIRED"
     if name.startswith("ddl_cleanup_detail_"):
@@ -49720,6 +49873,18 @@ def print_final_report(
             identity_sequence_grant_detail_path,
             len(identity_sequence_grant_rows) if identity_sequence_grant_detail_path else None,
             "identity sequence 跨 schema 授权明细"
+        )
+        fatal_error_matrix_rows = build_fatal_error_matrix_rows(settings)
+        fatal_error_matrix_path = export_fatal_error_matrix(
+            fatal_error_matrix_rows,
+            report_path.parent,
+            report_ts,
+        )
+        _add_index_entry(
+            "DETAIL",
+            fatal_error_matrix_path,
+            len(fatal_error_matrix_rows) if fatal_error_matrix_path else None,
+            "fatal error 场景矩阵"
         )
         manual_actions_path = export_manual_actions_required(
             manual_action_rows,

--- a/test_run_fixup.py
+++ b/test_run_fixup.py
@@ -1429,6 +1429,167 @@ class TestViewChainCycle(unittest.TestCase):
         self.assertEqual(sql_lines, [])
         self.assertTrue(any("CYCLE" in line for line in plan))
 
+    def test_build_view_chain_plan_requires_grant_option_for_cross_schema_table(self):
+        chains = [
+            [("A.V1", "VIEW"), ("B.T1", "TABLE")],
+        ]
+        grant_index = rf.GrantIndex({}, {}, {})
+        require_option_calls = []
+
+        def fake_plan_object_grant_for_dependency(
+            grantee,
+            target_full,
+            target_type,
+            required_priv,
+            require_grant_option,
+            *_args,
+            **_kwargs,
+        ):
+            require_option_calls.append(
+                (grantee, target_full, target_type, required_priv, require_grant_option)
+            )
+            return False
+
+        with mock.patch.object(rf, "plan_object_grant_for_dependency", side_effect=fake_plan_object_grant_for_dependency), \
+             mock.patch.object(rf, "check_object_exists", return_value=True), \
+             mock.patch.object(rf, "select_fixup_script_for_node_with_fallback", return_value=(None, None)):
+            plan, sql_lines, blocked = rf.build_view_chain_plan(
+                "A.V1",
+                chains,
+                [],
+                None,
+                {},
+                {},
+                {},
+                {},
+                grant_index,
+                grant_index,
+                False,
+                Path("."),
+                {},
+                {},
+                {},
+                {},
+                {},
+                set(),
+                set(),
+                set(),
+                set(),
+                set(),
+                None
+            )
+
+        self.assertFalse(blocked)
+        self.assertEqual(sql_lines, [])
+        self.assertEqual(len(require_option_calls), 1)
+        self.assertEqual(require_option_calls[0], ("A", "B.T1", "TABLE", "SELECT", True))
+
+    def test_build_auto_grant_plan_for_view_requires_grant_option_for_cross_schema_table(self):
+        ctx = rf.AutoGrantContext(
+            settings=rf.FixupAutoGrantSettings(enabled=True, types={"VIEW"}, fallback=False, cache_limit=10000, exec_mode="auto", exec_file_fallback=True),
+            deps_by_object={("A.V1", "VIEW"): {("B.T1", "TABLE")}},
+            grant_index_miss=rf.GrantIndex({}, {}, {}),
+            grant_index_all=rf.GrantIndex({}, {}, {}),
+            obclient_cmd=[],
+            timeout=None,
+            roles_cache={},
+            tab_privs_cache={},
+            tab_privs_grantable_cache={},
+            sys_privs_cache={},
+            planned_statements=set(),
+            planned_object_privs=set(),
+            planned_object_privs_with_option=set(),
+            planned_sys_privs=set(),
+            applied_grants=set(),
+            blocked_objects=set(),
+            stats=rf.AutoGrantStats(),
+        )
+        require_option_calls = []
+
+        def fake_plan_object_grant_for_dependency(
+            grantee,
+            target_full,
+            target_type,
+            required_priv,
+            require_grant_option,
+            *_args,
+            **_kwargs,
+        ):
+            require_option_calls.append(
+                (grantee, target_full, target_type, required_priv, require_grant_option)
+            )
+            return False
+
+        with mock.patch.object(rf, "plan_object_grant_for_dependency", side_effect=fake_plan_object_grant_for_dependency):
+            plan_lines, sql_lines, blocked = rf.build_auto_grant_plan_for_object(ctx, "A.V1", "VIEW")
+
+        self.assertEqual(plan_lines, [])
+        self.assertEqual(sql_lines, [])
+        self.assertFalse(blocked)
+        self.assertEqual(require_option_calls[0], ("A", "B.T1", "TABLE", "SELECT", True))
+
+    def test_infer_required_privileges_from_failed_statement_for_view_grant(self):
+        privs = rf.infer_required_privileges_from_failed_statement(
+            "GRANT UPDATE ON MONSTER_A.V1 TO U1;",
+            "MONSTER_A.V1",
+            "VIEW",
+        )
+        self.assertEqual(privs, {"UPDATE"})
+
+    def test_infer_permission_retry_target_for_view_post_grant(self):
+        target = rf.infer_permission_retry_target(
+            "GRANT UPDATE ON MONSTER_A.V1 TO U1;",
+            Path("fixup/view_post_grants/MONSTER_A.update.sql"),
+        )
+        self.assertEqual(target, ("MONSTER_A.V1", "VIEW", {"UPDATE"}))
+
+    def test_build_auto_grant_plan_for_view_uses_failed_grant_privilege_override(self):
+        ctx = rf.AutoGrantContext(
+            settings=rf.FixupAutoGrantSettings(enabled=True, types={"VIEW"}, fallback=False, cache_limit=10000, exec_mode="auto", exec_file_fallback=True),
+            deps_by_object={("A.V1", "VIEW"): {("B.T1", "TABLE")}},
+            grant_index_miss=rf.GrantIndex({}, {}, {}),
+            grant_index_all=rf.GrantIndex({}, {}, {}),
+            obclient_cmd=[],
+            timeout=None,
+            roles_cache={},
+            tab_privs_cache={},
+            tab_privs_grantable_cache={},
+            sys_privs_cache={},
+            planned_statements=set(),
+            planned_object_privs=set(),
+            planned_object_privs_with_option=set(),
+            planned_sys_privs=set(),
+            applied_grants=set(),
+            blocked_objects=set(),
+            stats=rf.AutoGrantStats(),
+        )
+        calls = []
+
+        def fake_plan_object_grant_for_dependency(
+            grantee,
+            target_full,
+            target_type,
+            required_priv,
+            require_grant_option,
+            *_args,
+            **_kwargs,
+        ):
+            calls.append((grantee, target_full, target_type, required_priv, require_grant_option))
+            return False
+
+        with mock.patch.object(rf, "plan_object_grant_for_dependency", side_effect=fake_plan_object_grant_for_dependency):
+            plan_lines, sql_lines, blocked = rf.build_auto_grant_plan_for_object(
+                ctx,
+                "A.V1",
+                "VIEW",
+                required_privileges_override={"UPDATE"},
+            )
+
+        self.assertEqual(plan_lines, [])
+        self.assertEqual(sql_lines, [])
+        self.assertFalse(blocked)
+        self.assertEqual(calls, [("A", "B.T1", "TABLE", "UPDATE", True)])
+
 
 class TestSqlParsing(unittest.TestCase):
     def test_split_nested_block_comments(self):

--- a/test_schema_diff_reconciler.py
+++ b/test_schema_diff_reconciler.py
@@ -3768,6 +3768,26 @@ class TestSchemaDiffReconcilerPureFunctions(unittest.TestCase):
             content,
         )
 
+    def test_export_fatal_error_matrix(self):
+        rows = [
+            sdr.FatalErrorMatrixRow(
+                category="SCOPED_TRIGGER_LIST",
+                trigger_condition="remap_root_closure + trigger_list 非法",
+                default_behavior="FATAL_ABORT",
+                currently_relevant="YES",
+                remediation="修正 trigger_list",
+            )
+        ]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = sdr.export_fatal_error_matrix(rows, Path(tmp_dir), "20260330_180000")
+            self.assertIsNotNone(path)
+            content = Path(path).read_text(encoding="utf-8")
+        self.assertIn("Fatal error 场景矩阵", content)
+        self.assertIn(
+            "SCOPED_TRIGGER_LIST|remap_root_closure + trigger_list 非法|FATAL_ABORT|YES|修正 trigger_list",
+            content,
+        )
+
     def test_locate_target_identity_sequences_object_id_match(self):
         ob_meta = self._make_ob_meta()._replace(
             objects_by_type={"TABLE": {"TGT.T1"}},


### PR DESCRIPTION
## Summary
- harden ORA-01720-sensitive VIEW grant dependency handling
- let run_fixup recover permission-denied grant-file failures by parsing the failed GRANT and auto-granting the underlying dependency privilege with WITH GRANT OPTION where required
- add fatal_error_matrix_<ts>.txt to report output and report index
- document the new behavior in README / readme_config / technical spec

## Verification
- `python3 -m py_compile $(git ls-files '*.py')`
- `.venv/bin/python -m unittest test_schema_diff_reconciler test_run_fixup`
- `pytest -q`
- `openspec validate add-ora01720-grant-dependency-hardening --strict`
- `openspec validate --changes --strict`

## Unit / Static Results
- `unittest`: `Ran 774 tests`, `OK`
- `pytest -q`: `803 passed, 2 skipped`
- `py_compile`: passed
- OpenSpec validations: passed

## Real DB Evidence
### 1. comparator prerequisite grant generation
- config: `/tmp/ora01720_case_0330/with_grants/config.ini`
- compare:
  - `.venv/bin/python schema_diff_reconciler.py /tmp/ora01720_case_0330/with_grants/config.ini`
- generated prerequisite grant:
  - `/tmp/ora01720_case_0330/with_grants/fixup/view_prereq_grants/PA.grants.sql`
  - contains `GRANT SELECT ON PA.CODX_ORA01720_BASE_0330 TO MONSTER_A WITH GRANT OPTION;`
- generated post grant:
  - `/tmp/ora01720_case_0330/with_grants/fixup/view_post_grants/MONSTER_A.grants.sql`

### 2. runtime ORA-01720 recovery
- config: `/tmp/ora01720_case_0330/no_grants/config.ini`
- direct OB proof before fixup:
  - `GRANT UPDATE ON MONSTER_A.CODX_ORA01720_V_0330 TO MONSTER_B`
  - returned `ORA-01720: grant option does not exist for 'PA.CODX_ORA01720_BASE_0330'`
- manual grant-file replay:
  - `/tmp/ora01720_case_0330/no_grants/fixup/view_post_grants/MONSTER_A.update.sql`
  - `.venv/bin/python run_fixup.py /tmp/ora01720_case_0330/no_grants/config.ini --only-dirs view_post_grants --glob '*MONSTER_A.update.sql'`
- observed runtime behavior:
  - first attempt failed with ORA-01720
  - run_fixup parsed the failed `GRANT UPDATE ON VIEW ...`
  - auto-grant applied the dependency grant with `WITH GRANT OPTION`
  - retry succeeded and moved the script to `done/view_post_grants/`
- target verification after execution:
  - `DBA_TAB_PRIVS` shows:
    - `MONSTER_A UPDATE on PA.CODX_ORA01720_BASE_0330 GRANTABLE=YES`
    - `MONSTER_B UPDATE on MONSTER_A.CODX_ORA01720_V_0330 GRANTABLE=NO`

### 3. fatal matrix artifact
- report artifact example:
  - `/tmp/ora01720_case_0330/no_grants/reports/run_20260330_184255/fatal_error_matrix_20260330_184255.txt`
- includes category / trigger condition / default behavior / currently relevant / remediation
