### PR TITLE
Clarify constraint validate later reporting

### DIFF
--- a/schema_diff_reconciler.py
+++ b/schema_diff_reconciler.py
@@ -32930,14 +32930,14 @@ def write_fixup_root_readme(
         "trigger": "缺失 TRIGGER 的 CREATE 脚本。",
         "compile": "依赖重编译脚本。",
         "name_collision": "重名约束/索引处理脚本，通常应先于 constraint/index。",
-        "constraint_validate_later": "后置 VALIDATE 脚本，默认不建议首次执行。",
+        "constraint_validate_later": "后置 VALIDATE 脚本，仅针对“先 NOVALIDATE 落地、最终需 VALIDATED”的缺失约束；默认不建议首次执行。",
         "grants_miss": "缺失授权脚本，适合补齐当前缺口。",
         "grants_all": "全量授权审计脚本，主要用于核对，不等于都要执行。",
         "grants_deferred": "延后授权脚本，需对象补齐后再执行。",
         "grants_revoke": "目标端多余 PUBLIC 授权回收建议，先审后执行。",
         "view_prereq_grants": "VIEW 前置授权，通常先于 view/ 执行。",
         "view_post_grants": "VIEW 创建后授权。",
-        "status": "状态漂移修补脚本（trigger/constraint）。",
+        "status": "状态漂移修补脚本（trigger/constraint）；缺失 TABLE 首次创建后恢复 ENABLE NOVALIDATE 也在这里。",
         "job": "JOB 草案或修补脚本，通常需人工确认。",
         "schedule": "SCHEDULE 草案或修补脚本，通常需人工确认。",
         "cleanup_candidates": "目标端多余对象清理候选总览，默认不自动执行。",
@@ -40163,6 +40163,11 @@ def export_constraint_validate_deferred_detail(
         "REASON",
         "VALIDATE_SQL"
     ]
+    notes = [
+        "仅覆盖：缺失约束当前以 ENABLE NOVALIDATE 落地，但源端最终语义需要 VALIDATED 的场景。",
+        "若源端本来就是 ENABLED + NOT VALIDATED，则不会进入 constraint_validate_later/；",
+        "对于“缺失 TABLE 首次创建 + ENABLED + NOT VALIDATED”的约束，会改由 fixup/status/constraint/ 恢复 ENABLE NOVALIDATE。",
+    ]
     data_rows = [
         [
             row.schema_name,
@@ -40176,7 +40181,28 @@ def export_constraint_validate_deferred_detail(
         ]
         for row in rows_sorted
     ]
-    return write_pipe_report("约束后置 VALIDATE 明细", header_fields, data_rows, output_path)
+    delimiter = "|"
+    header = delimiter.join(header_fields)
+    lines: List[str] = [
+        "# 约束后置 VALIDATE 明细",
+        f"# total={len(data_rows)}",
+        "# 分隔符: |",
+    ]
+    for note in notes:
+        lines.append(f"# note: {note}")
+    lines.extend([
+        f"# 字段说明: {header}",
+        header,
+    ])
+    for row in data_rows:
+        lines.append(delimiter.join(sanitize_pipe_field(item) for item in row))
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+        return output_path
+    except OSError as exc:
+        log.warning("写入报告失败 %s: %s", output_path, exc)
+        return None
 
 
 def export_name_collision_detail(
@@ -42838,8 +42864,8 @@ def build_operator_action_rows(
         default_behavior="GENERATED_AFTER_PREREQ",
         primary_artifact=_derive_run_artifact_path(report_dir, report_timestamp, "constraint_validate_deferred_detail"),
         related_fixup_dir="constraint_validate_later/",
-        why="这些约束被故意后置到数据清理后再 VALIDATE。",
-        recommended_action="先完成脏数据清理，再执行 constraint_validate_later/。",
+        why="这些约束当前先以 ENABLE NOVALIDATE 落地，但源端最终语义要求 VALIDATED，因此被故意后置到数据清理后再 VALIDATE。",
+        recommended_action="先完成脏数据清理，再执行 constraint_validate_later/。若源端本来就是 NOT VALIDATED，请改看 status/constraint/ 的 ENABLE NOVALIDATE 恢复脚本，而不是本目录。",
     )
     _add(
         priority="REVIEW",

--- a/test_schema_diff_reconciler.py
+++ b/test_schema_diff_reconciler.py
@@ -12512,10 +12512,33 @@ class TestSchemaDiffReconcilerPureFunctions(unittest.TestCase):
             self.assertIn("PRIORITY|STAGE|CATEGORY|COUNT|DEFAULT_BEHAVIOR", content)
             self.assertIn("BLOCKER|BEFORE_FIXUP|DATA_RISK|2|REPORT_ONLY", content)
 
+    def test_export_constraint_validate_deferred_detail_includes_scope_note(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rows = [
+                sdr.ConstraintValidateDeferredRow(
+                    schema_name="OMS_USER",
+                    table_name="T1",
+                    constraint_name="FK_T1_PARENT",
+                    constraint_type="R",
+                    src_validated="VALIDATED",
+                    applied_mode="safe_novalidate",
+                    reason="safe_novalidate",
+                    validate_sql='ALTER TABLE "OMS_USER"."T1" ENABLE VALIDATE CONSTRAINT "FK_T1_PARENT";',
+                )
+            ]
+            output = sdr.export_constraint_validate_deferred_detail(rows, Path(tmpdir), "123")
+            self.assertIsNotNone(output)
+            content = Path(output).read_text(encoding="utf-8")
+            self.assertIn("仅覆盖：缺失约束当前以 ENABLE NOVALIDATE 落地", content)
+            self.assertIn("不会进入 constraint_validate_later/", content)
+            self.assertIn("fixup/status/constraint/", content)
+
     def test_write_fixup_root_readme_points_to_manual_actions(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             base_dir = Path(tmpdir) / "fixup_scripts"
             (base_dir / "grants_miss").mkdir(parents=True)
+            (base_dir / "constraint_validate_later").mkdir(parents=True)
+            (base_dir / "status").mkdir(parents=True)
             report_dir = Path(tmpdir) / "reports"
             report_dir.mkdir(parents=True)
             manual_path = report_dir / "manual_actions_required_123.txt"
@@ -12524,7 +12547,7 @@ class TestSchemaDiffReconcilerPureFunctions(unittest.TestCase):
                 base_dir,
                 report_dir,
                 "123",
-                generated_dirs=["grants_miss"],
+                generated_dirs=["grants_miss", "constraint_validate_later", "status"],
                 manual_actions_path=manual_path,
                 unsupported_grant_count=3,
                 deferred_grant_count=0,
@@ -12532,6 +12555,8 @@ class TestSchemaDiffReconcilerPureFunctions(unittest.TestCase):
             content = Path(output).read_text(encoding="utf-8")
             self.assertIn(str(manual_path), content)
             self.assertIn("grants_miss/ 不是完整授权闭环", content)
+            self.assertIn("先 NOVALIDATE 落地、最终需 VALIDATED", content)
+            self.assertIn("恢复 ENABLE NOVALIDATE 也在这里", content)
 
     def test_build_report_index_guide_entries_prioritizes_manual_actions(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- clarify the reporting and operator guidance around `constraint_validate_later`
- distinguish deferred VALIDATE from post-create `ENABLE NOVALIDATE` restoration under `status/constraint`
- keep execution logic unchanged; this is an explanation/reporting improvement

## Verification
- `python3 -m py_compile $(git ls-files '*.py')`
- `.venv/bin/python -m unittest test_schema_diff_reconciler test_run_fixup`
- `pytest -q`
- `openspec validate clarify-constraint-validate-later-reporting --strict`
- `openspec validate add-ora01720-grant-dependency-hardening --strict`
- `openspec validate --changes --strict`

## Unit / Static Results
- `unittest`: `Ran 775 tests`, `OK`
- `pytest -q`: `804 passed, 2 skipped`
- `py_compile`: passed
- OpenSpec validations: passed

## Real DB Evidence
- case config: `/tmp/constraint_validate_case_0331/config.ini`
- source VALIDATED missing FK:
  - `fixup/constraint/OMS_USER.FK_CODX_CVL_CHILD_0331.sql` created with `ENABLE NOVALIDATE`
  - `fixup/constraint_validate_later/OMS_USER.constraint_validate.sql` created with `ENABLE VALIDATE`
- source NOT VALIDATED missing FK:
  - `fixup/constraint/OMS_USER.FK_CODX_CVN_CHILD_0331.sql` created with `ENABLE NOVALIDATE`
  - no `constraint_validate_later` entry generated
- missing-table first-create NOT VALIDATED FK:
  - `fixup/status/constraint/OMS_USER.FK_CODX_CVM_CHILD_0331.status.sql`
  - restores `ENABLE NOVALIDATE`

This confirms the existing logic is correct and the change is explanatory only.
