### PR TITLE
fix: ship v0.9.9.4 remediation release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
 # OceanBase Comparator Toolkit
 
-> 当前版本：V0.9.9.3
+> 当前版本：V0.9.9.4
 > 面向 Oracle → OceanBase 与 OceanBase → OceanBase 的结构一致性校验与修补脚本生成工具  
 > 核心理念：一次转储、本地对比、脚本审计优先
 
-## 近期更新（0.9.9.3）
+## 近期更新（0.9.9.4）
 - 新增 `source_db_mode=oceanbase` 与 `[OCEANBASE_SOURCE]`，主程序现在支持 OceanBase Oracle-mode source → OceanBase target 的严格 compare 与 certified fixup family。
 - OB→OB 模式下已打通源端 metadata / dependency / DDL provider 分发，支持同 endpoint 与跨版本场景；当前 certified family 包含 TABLE、VIEW、PROCEDURE、FUNCTION、PACKAGE、PACKAGE BODY、CONTEXT、SYNONYM、SEQUENCE、TRIGGER、TYPE、TYPE BODY、INDEX、CONSTRAINT。
 - Oracle-only 规则已完成 mode 隔离：OB→OB 不再误复用 Oracle 的 GTT rewrite、OMS exclusion、VARCHAR 长度膨胀等迁移改写；strict compare 产生的 `type_literal_mismatch` 会落成可执行 `ALTER TABLE ... MODIFY`。
 - 新增 application context compare/fixup：可读取 `DBA_CONTEXT`，从 `VIEW/PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY/TRIGGER/TYPE BODY` 抽取字面量 `SYS_CONTEXT` / `DBMS_SESSION.SET_CONTEXT` 引用，并对 OB 目标端按语法安全方式生成 `CREATE CONTEXT`（`ACCESSED LOCALLY` 会正确映射为“省略 clause”）。
 - 报告和 fixup 目录已显式暴露 source mode、source/target version、capability gate 与 deferred/manual family，避免“看起来能跑、实际上部分能力未启用”的误判。
+- 兼容敏感默认值现在会显式告警：`report_to_db` 若省略会提示“当前按 false 处理”；`source_db_mode=oceanbase` 下若省略 `synonym_check_scope/synonym_fixup_scope`，会提示“当前默认按 all 处理”，不再静默切换。
+- GTT 合约已补齐 `gtt_table_handling_mode=auto` 与版本门控；`rewrite_to_normal` 的 `ON COMMIT` 语义损失会进入主报告、runtime notices、`manual_actions_required_<ts>.txt` 与脚本头注释。
+- `remap_root_closure + remap_scope_text_fallback_mode=safe` 现在可识别源码中静态 `DBMS_SCHEDULER.CREATE_JOB/CREATE_SCHEDULE` 名称，把命中的 JOB/SCHEDULE 纳入 closure；动态表达式会写入 `source_scope_detail_<ts>.txt` 供人工复核。
 - Oracle→OB 默认链路保持不变，`source_db_mode=oracle` 仍是默认模式；本版全量回归通过，旧路径未被打坏。
 
 ## 核心能力
 - **对象覆盖完整**：TABLE/VIEW/MVIEW/PLSQL/TYPE/JOB/SCHEDULE + INDEX/CONSTRAINT/SEQUENCE/TRIGGER。
 - **Dump-Once 架构**：Oracle Thick Mode + 少量 obclient 调用，元数据一次性落本地内存。
 - **Remap 推导**：支持显式规则、依附对象跟随、依赖推导、schema 回退策略。
-- **源范围收缩模式**：支持 `source_object_scope_mode=remap_root_closure`，仅以 `remap_file` 中显式 TABLE/VIEW 为根种子，按依赖、反向依赖、附属关系扩展闭包；闭包外对象整体忽略，`trigger_list` 可作为显式 keep set。
+- **源范围收缩模式**：支持 `source_object_scope_mode=explicit_roots|remap_root_closure`。`explicit_roots` 仅保留 `remap_file` 中显式 TABLE/VIEW roots 及其附属对象；`remap_root_closure` 再按依赖、反向依赖和附属关系扩展闭包；两种模式都支持 `trigger_list` 作为显式 keep set。
 - **scoped 文本补盲**：支持 `remap_scope_text_fallback_mode=safe`，仅从 `DBA_SOURCE` / `DBA_VIEWS.TEXT` / `DBA_MVIEWS.QUERY` / scheduler 文本等受控来源补盲；支持受控 dynamic SQL、纯字符串拼接 SQL 以及 same-schema 未带前缀调用补盲，不走全 schema DDL grep。变量拼接 SQL 仅报告，不自动纳入。
 - **黑名单表重纳管**：支持 `blacklist_target_existing_policy=rehydrate_if_present`；当源端黑名单表已在目标端被人工改造并创建为 TABLE 时，可恢复后续 compare/fixup，但会自动保护黑名单改造列，避免把 Oracle 原始类型/长度/default/nullability 再写回 OB。
 - **Target Scope 一等公民**：目标端受管 schema 不再等同于 `source_schemas`；会按 remap/full mapping 自动推导，哪怕 remap 到全新的目标 schema，也会继续进入 compare/fixup/report。
@@ -40,7 +43,7 @@
 - **表数据风险校验**：`table_data_presence_check` 识别“源端有数据、目标空表”风险；`auto` 为统计口径，`on` 为严格回表。
 - **对象时间截断**：`object_created_before` 可按 `CREATED` 截止时间冻结校验范围，支持缺失 CREATED 策略（`strict/include_missing/exclude_missing`），并输出 `objects_after_cutoff_detail_<ts>.txt` 与 report_db 对齐明细。
 - **run_fixup 增强**：支持 `--iterative`、`--view-chain-autofix`、语句级继续执行、授权修剪与错误报告。
-- **run_fixup 安全门禁**：默认跳过 `fixup_scripts/table/`，需显式 `--allow-table-create` 才执行建表脚本。
+- **run_fixup 安全门禁**：默认跳过 `fixup_scripts/table/`；`fixup_scripts/materialized_view/`、`fixup_scripts/job/`、`fixup_scripts/schedule/` 也按 manual-only family 默认跳过，需显式按目录执行；即便显式配合 `--iterative`，失败后也只保留到错误报告，不会跨轮自动重试。
 - **状态漂移修复**：支持 TRIGGER/CONSTRAINT 的状态差异检测与状态修补脚本生成。
 - **约束策略增强**：支持缺失约束的 `safe_novalidate/source/force_validate` 策略；仅当源端最终语义需要 `VALIDATED` 时，才生成后置 `validate_later` 脚本。对“缺失 TABLE 首次创建”场景，若源端 `FK/CHECK` 为 `ENABLED + NOT VALIDATED`，会同轮追加 `fixup/status/constraint/*.status.sql` 恢复 `ENABLE NOVALIDATE` 语义。
 - **约束状态修复默认更严格**：`constraint_status_sync_mode` 默认改为 `full`，现有 `FK/CHECK` 的 `VALIDATED / NOT VALIDATED` 漂移会默认进入状态校验与状态修复脚本；`PK/UK` 的 `VALIDATED / NOT VALIDATED` 漂移也会进入状态漂移报告，但仍不生成 `ENABLE/[NO]VALIDATE` SQL。
@@ -66,6 +69,12 @@
 - SQLcl（可选，用于 DDL 格式化）
 - 运行账号需具备 DBA_* 视图访问权限（Oracle 与 OB）
 - 安全说明：工具运行时不会把 OB/dbcat 密码作为明文参数暴露在 `ps` 命令中（配置文件仍按当前方式保留密码项）。
+
+## 运维提示（0.9.9.4）
+- Oracle -> OB：默认链路不变；若省略 `synonym_check_scope/synonym_fixup_scope`，仍按 `public_only` 运行。target-side `DBA_SYNONYMS` 补查不再静默扩大范围，只在明确需要的 OB source 路径启用。
+- OB -> OB：若省略 `synonym_check_scope/synonym_fixup_scope`，运行时会提示并按 `all` 处理；OB source 的多行 `DATA_DEFAULT` 会先做控制字符清理，避免错列。
+- GTT：可继续显式使用 `rewrite_to_normal/preserve_original/blocked`；也可以用 `auto` 让程序按目标 OB 版本决策。凡是落到 `rewrite_to_normal`，都要把它视为“结构可迁、事务语义需人工确认”。
+- scoped closure：`safe` 文本补盲现在支持静态 `DBMS_SCHEDULER.CREATE_JOB/CREATE_SCHEDULE`；如果 `job_name/schedule_name` 不是静态字面量，报告会提示 unresolved，而不会盲猜。
 
 ## 贡献方式
 
@@ -147,6 +156,7 @@ config_hot_reload_interval_sec = 5
 config_hot_reload_fail_policy = keep_last_good
 
 Note: when `source_db_mode = oceanbase` and these two keys are omitted, the runtime default becomes `all`; Oracle mode keeps `public_only`.
+Note: if `report_to_db` is omitted, runtime will warn that it is being treated as `false`; environments depending on report_db should set it explicitly.
 oracle_client_lib_dir = /opt/instantclient_19_28
 dbcat_bin = /opt/dbcat-2.5.0-SNAPSHOT
 dbcat_output_dir = dbcat_output
@@ -154,7 +164,7 @@ java_home = /usr/lib/jvm/java-11
 ```
 说明：
 - `source_db_mode=oracle` 保持原有 Oracle -> OceanBase 行为。
-- `source_db_mode=oceanbase` 现在支持 OceanBase -> OceanBase 的严格 compare 与 certified fixup family；授权生成、Oracle blacklist/source usability 等未认证能力会显式转 deferred/manual。
+- `source_db_mode=oceanbase` 现在支持 OceanBase -> OceanBase 的严格 compare 与 certified fixup family；`generate_grants`、`object_created_before`、`check_object_usability`、`table_data_presence_check`、`explicit_roots/remap_root_closure` 都按产品模式生效，Oracle blacklist 语义仅保留诊断提示，不进入 OB source 主链路。
 - `source_db_mode=oceanbase` 当前的 TRIGGER 覆盖范围是 table/view-based trigger；`DATABASE/SCHEMA` 级非表触发器仍按 deferred/manual 处理。
 
 完整配置说明见 `readme_config.txt`。
@@ -281,7 +291,7 @@ python3 run_fixup.py --smart-order --recompile --allow-table-create
 - `main_reports/run_<ts>/sys_c_force_candidates_detail_<ts>.txt`：SYS_C* FORCE 候选表明细（用于评估是否开启 `fixup_drop_sys_c_columns`）
 - `main_reports/run_<ts>/missing_objects_detail_<ts>.txt`：缺失对象支持性明细（report_detail_mode=split）
 - `main_reports/run_<ts>/unsupported_objects_detail_<ts>.txt`：不支持/阻断对象明细（report_detail_mode=split）
-- `main_reports/run_<ts>/source_scope_detail_<ts>.txt`：源对象范围明细（`source_object_scope_mode=remap_root_closure` 时的 roots/closure/filter 诊断，必要时追加 `INTEGRITY_CRITICAL` / `INTEGRITY_WARNING`）
+- `main_reports/run_<ts>/source_scope_detail_<ts>.txt`：源对象范围明细（`source_object_scope_mode=explicit_roots|remap_root_closure` 时的 roots/filter 诊断；closure 模式下还会追加依赖扩展与 `INTEGRITY_*`）
 - `main_reports/run_<ts>/scope_integrity_detail_<ts>.txt`：scope 完整性明细（blocking `VIEW/MVIEW` + 可选 advisory-family `INFO`）
 - `main_reports/run_<ts>/scope_integrity_remap_candidates_<ts>.txt`：可直接补入 remap 文件的候选对象清单
 - `main_reports/run_<ts>/runtime_degraded_detail_<ts>.txt`：运行时降级明细（区分 `COMPARE` 与 `ARTIFACT`；若存在 `COMPARE`，主报告会标记 `compare incomplete`）
@@ -309,7 +319,7 @@ python3 run_fixup.py --smart-order --recompile --allow-table-create
 - `main_reports/run_<ts>/column_default_detail_<ts>.txt`：现有列默认值差异明细（仅列级语义，不等同 `DEFAULT ON NULL`）
 - `main_reports/run_<ts>/dependency_detail_<ts>.txt`：依赖差异明细（report_detail_mode=split）
 - `*_detail_*.txt` 明细文件采用 `|` 分隔，并包含 `# total/# 字段说明` 头，格式与 `package_compare` 一致，便于 Excel 直接分隔导入。
-- `main_reports/run_<ts>/missed_tables_views_for_OMS/`：OMS 缺失 TABLE/VIEW 规则；当 `source_object_scope_mode=remap_root_closure` 时，这里默认只导出 `remap_file` 中显式 TABLE/VIEW roots，不再把 closure 中的依赖对象一起导出
+- `main_reports/run_<ts>/missed_tables_views_for_OMS/`：OMS 缺失 TABLE/VIEW 规则；当 `source_object_scope_mode=explicit_roots|remap_root_closure` 时，这里默认只导出 `remap_file` 中显式 TABLE/VIEW roots，不再把依赖扩展对象一起导出
 - `fixup_scripts/`：修补脚本输出（执行前需人工审核）
 - `fixup_scripts/README_FIRST.txt`：fixup 根目录导航，说明本次生成目录的用途与默认执行边界；若存在人工项，会先指向 `manual_actions_required_<ts>.txt`
 - `fixup_scripts/grants_miss/`：缺失授权脚本
@@ -335,7 +345,7 @@ python3 run_fixup.py --smart-order --recompile --allow-table-create
 - 如果触发器字符串字面量完整等于 `SCHEMA.OBJECT`，也会按 remap 自动改写，例如 `'LIFEBASE.T1' -> 'BASEDATA.T1'`。
 - 如果字符串字面量是 `SCHEMA.OBJECT.COLUMN` 三段式路径，程序默认不自动改写，避免把列名、协议文本或日志内容误改坏；这类情况会输出到 `triggers_literal_object_path_detail_<ts>.txt` 供人工确认。
 - 如果源端触发器是 `DATABASE/SCHEMA` 级事件触发器（例如 `BEFORE DROP ON DATABASE`），程序不会再静默漏掉；会输出到 `triggers_non_table_detail_<ts>.txt`，并在 `manual_actions_required_<ts>.txt` 中显式提醒。`INSTEAD OF ... ON VIEW` 会按普通受管触发器参与 compare/fixup。
-- 当 `source_object_scope_mode=remap_root_closure` 且配置了 `trigger_list` 时，`trigger_list` 支持填写源端名或 remap 后目标名；若条目无法在源端或显式 remap 规则中解析，只会写入 `source_scope_detail_<ts>.txt` / `trigger_status_report.txt`，不会再中止整轮运行。
+- 当 `source_object_scope_mode=explicit_roots|remap_root_closure` 且配置了 `trigger_list` 时，`trigger_list` 支持填写源端名或 remap 后目标名；若条目无法在源端或显式 remap 规则中解析，只会写入 `source_scope_detail_<ts>.txt` / `trigger_status_report.txt`，不会再中止整轮运行。
 - 在 scoped trigger 场景下，如果触发器依赖的目标 TABLE/VIEW 尚未创建，首轮只会生成依赖对象脚本；TRIGGER 自身会在 `fixup_skip_summary_<ts>.txt` 中标记为 `base_table_missing` 或同类跳过原因，待依赖补齐后 rerun 再生成 trigger DDL。
 - 若配置了 `trigger_list`，`trigger_status_report.txt` 与运行总结中的 `compare缺失 / 命中缺失 / 过滤` 使用同一套 trigger list 口径；`fixup_skip_summary_<ts>.txt` 则继续在此基础上区分 `selected_total / task_total / blocked_total`，避免把“清单命中”误读成“已可生成脚本”。
 - 对 `TABLE/VIEW` 前置依赖已缺失、或已被纳入人工/不支持处理的 `INDEX / CONSTRAINT / TRIGGER`，fixup 入口会先按与主报告相同的 compare scope 过滤，不再出现“检查汇总已剔除、fixup_skip_summary 仍重复计数”的分叉。
@@ -351,10 +361,10 @@ python3 run_fixup.py --smart-order --recompile --allow-table-create
 - `TYPE ... NOT PERSISTABLE` 当前按源端语义保留，不会被默认清洗成普通 TYPE，也不会因为该子句差异额外制造 TYPE mismatch 噪声。
 
 ## 黑名单规则
-- 默认启用 `blacklist_rules.json` 规则并尝试读取 `OMS_USER.TMP_BLACK_TABLE`（`blacklist_mode=auto`）。
-- 可通过 `blacklist_mode` 切换来源（table_only/rules_only/disabled），或用 `blacklist_rules_enable/disable` 精细控制规则。
+- Oracle source 路径默认启用 `blacklist_rules.json` 规则并尝试读取 `OMS_USER.TMP_BLACK_TABLE`（`blacklist_mode=auto`）。
+- Oracle source 可通过 `blacklist_mode` 切换来源（table_only/rules_only/disabled），或用 `blacklist_rules_enable/disable` 精细控制规则。
 - LOB 体积阈值由 `blacklist_lob_max_mb` 控制（默认 512MB）。
-- 当使用 `blacklist_mode=auto` 或 `rules_only` 时，请确保 `blacklist_rules.json` 随工具部署；缺失时规则会被跳过。
+- 当使用 `blacklist_mode=auto` 或 `rules_only` 时，请确保 `blacklist_rules.json` 随工具部署；`source_db_mode=oceanbase` 下该能力仅保留诊断提示，不进入 OB source compare/fixup 主链路。
 - 推荐用 `exclude_objects_file` 维护“明确不参与校验”的对象清单（`TYPE|SCHEMA|OBJECT`）；未配置时不生效，继续原有逻辑。
 
 ## 常见配置片段

--- a/config.ini.template.txt
+++ b/config.ini.template.txt
@@ -27,7 +27,7 @@ password    = your_password
 [SETTINGS]
 # 源端数据库类型：
 #   oracle    -> 默认，Oracle -> OceanBase
-#   oceanbase -> OceanBase -> OceanBase（已支持 compare + certified fixup；grant/Oracle blacklist 等未认证能力会转 deferred/manual）
+#   oceanbase -> OceanBase -> OceanBase（已支持 compare + certified fixup；grants/source usability/table presence/cutoff/product-mode scope 可直接启用；Oracle blacklist 仅保留诊断提示）
 source_db_mode         = oracle
 # 要扫描的所有源端 schema，用逗号分隔，可换行（大小写不敏感）
 source_schemas          = ORA_APP,ORA_FIN,ORA_BI
@@ -36,13 +36,16 @@ source_schemas          = ORA_APP,ORA_FIN,ORA_BI
 remap_file              = remap_rules.txt
 # 源对象范围模式：
 #   full_source        -> 当前默认行为：基于 source_schemas 全量扫描
-#   remap_root_closure -> 仅以 remap_file 中显式 TABLE/VIEW 为根种子，按依赖/附属关系扩展闭包
-#                         trigger_list 中显式列出的触发器会作为额外 keep set 保留
+#   explicit_roots     -> 仅保留 remap_file 中显式 TABLE/VIEW roots 及其附属对象
+#   remap_root_closure -> 以 remap_file 中显式 TABLE/VIEW 为根种子，按依赖/附属关系扩展闭包
+#                         两种 scoped 模式下，trigger_list 中显式列出的触发器都会作为额外 keep set 保留
 source_object_scope_mode = full_source
 # remap_scope_text_fallback_mode：scoped 文本补盲模式
 #   off  -> 关闭（默认）
 #   safe -> 仅从 DBA_SOURCE/DBA_VIEWS/DBA_MVIEWS/DBA_SCHEDULER_* 等受控文本来源补盲
 #           不做全 schema DBMS_METADATA 全量 grep
+#           额外支持静态 DBMS_SCHEDULER.CREATE_JOB/CREATE_SCHEDULE 名称补盲；
+#           动态 job_name/schedule_name 会写入 source_scope_detail_<ts>.txt 供人工复核
 remap_scope_text_fallback_mode = off
 # scope_integrity_check：是否检查 remap_root_closure 下 scoped VIEW/MVIEW 的前置依赖完整性
 #   true  -> 输出 blocking prerequisite 诊断（默认）
@@ -111,6 +114,7 @@ report_dir_layout       = per_run
 report_detail_mode      = split
 # 报告存库（默认关闭，按需开启）
 # report_to_db: 是否写入 OceanBase（obclient 方式）
+#   备注：若省略该项，运行时会显式提示“当前按 false 处理”；依赖 report_db 的环境建议明确写出 true/false
 # report_db_schema: 存储 schema（留空使用目标连接用户）
 #   非空时必须是 Oracle 普通标识符，例如 DIFF_REPORT（不允许点号/引号/分号）
 # report_retention_days: 历史保留天数（0 表示不清理）
@@ -193,6 +197,9 @@ mview_check_fixup_mode  = auto
 # rewrite_to_normal : 将 Oracle GTT 生成成普通 TABLE DDL（默认）
 # preserve_original : 保留 Oracle GTT 语义原样输出
 # blocked           : 保持旧行为，继续走 unsupported/temporary 路径
+# auto              : 按目标 OB 版本自动在 preserve_original / rewrite_to_normal 之间选择
+#                     若显式 preserve_original 但目标版本不支持，会自动降级为 blocked
+# 注意：rewrite_to_normal 会丢失 ON COMMIT 事务清理语义，主报告和 manual_actions_required 会显式提示
 gtt_table_handling_mode = rewrite_to_normal
 # 是否生成目标端“多余对象”清理候选
 # 普通候选仍以注释形式输出；若识别到“目标端重复的单列 IS NOT NULL 语义 CHECK”，
@@ -219,7 +226,7 @@ interval_partition_cutoff = 20280301
 # interval_partition_cutoff_numeric: 数值型 interval 分区补齐上限（仅数值分区键使用），如 100000
 interval_partition_cutoff_numeric =
 # 是否生成授权脚本并附加到修补 DDL（依赖于源端权限/依赖推导）
-# 注意：source_db_mode=oceanbase 下当前会自动门控关闭
+# source_db_mode=oceanbase 下会按 OB source inventory 正常生成 role/system/object/column privilege 缺失授权
 # 可选值：true/false/1/0/yes/no（大小写不敏感）
 generate_grants         = true
 # 授权生成模式
@@ -280,6 +287,8 @@ fixup_types             =
 # JOB/SCHEDULE 修补模式：
 #   manual    -> 仅标记不支持，不生成脚本（默认）
 #   semi_auto -> 当源端 DDL 缺失时，生成草案模板到 fixup_scripts/unsupported/job|schedule/
+# 说明：run_fixup 默认跳过 fixup_scripts/job/ 与 fixup_scripts/schedule/，需显式 --only-dirs job|schedule
+# 说明：即便显式配合 --iterative，JOB/SCHEDULE 失败后也只写入 errors/fixup_errors_<ts>.txt，不会跨轮自动重试
 job_schedule_fixup_mode = manual
 # 普通 NOT NULL 收紧输出模式：
 #   review_only         -> 保持 review-first 注释
@@ -299,6 +308,7 @@ fixup_idempotent_types  =
 #   all         -> 生成 PUBLIC + 私有同义词
 #   public_only -> 仅生成 PUBLIC 同义词
 # 默认：Oracle 源 public_only；OceanBase 源 all。此模板示例按 Oracle 路径保留 public_only。
+# 提示：OceanBase 源若省略该项，运行时会显式提示“当前默认按 all 处理”。
 synonym_fixup_scope     = public_only
 # 约束/索引重名处理模式：
 #   off    -> 关闭
@@ -325,6 +335,7 @@ trigger_qualify_schema  = true
 #   public_only -> 仅将 PUBLIC 同义词纳入主校验与检查汇总
 #   all         -> PUBLIC + 私有同义词全部纳入校验
 # 默认：Oracle 源 public_only；OceanBase 源 all。此模板示例按 Oracle 路径保留 public_only。
+# 提示：OceanBase 源若省略该项，运行时会显式提示“当前默认按 all 处理”。
 # check_extra_types 可选值：
 #   INDEX, CONSTRAINT, SEQUENCE, TRIGGER
 # check_status_drift_types 可选值：
@@ -419,6 +430,7 @@ column_visibility_policy = auto
 #   table_only -> 仅使用 TMP_BLACK_TABLE
 #   rules_only -> 仅使用规则文件
 #   disabled   -> 关闭黑名单过滤
+# 说明：该能力面向 Oracle source；source_db_mode=oceanbase 下仅保留诊断提示，不进入 OB source compare/fixup 主链路
 blacklist_mode          = auto
 # 黑名单规则文件（JSON），留空使用内置默认
 # 注意：blacklist_mode=auto/rules_only 时需保证该文件随工具一同部署，否则规则会被跳过

--- a/init_users_roles.py
+++ b/init_users_roles.py
@@ -36,7 +36,7 @@ import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
-__version__ = "0.9.9.3"
+__version__ = "0.9.9.4"
 
 try:
     import oracledb
@@ -59,17 +59,29 @@ LOG_FILE_FORMAT = "%(asctime)s | %(levelname)-8s | %(message)s"
 IDENT_SIMPLE_RE = re.compile(r"^[A-Z][A-Z0-9_$#]*$")
 _SECURE_CREDENTIAL_FILES: Set[Path] = set()
 FALLBACK_SYSTEM_ROLE_NAMES: Set[str] = {
+    "ADM_PARALLEL_EXECUTE_TASK",
     "AQ_ADMINISTRATOR_ROLE",
     "AQ_USER_ROLE",
+    "CAPTURE_ADMIN",
     "CONNECT",
     "CTXAPP",
+    "CDB_DBA",
     "DATAPUMP_EXP_FULL_DATABASE",
     "DATAPUMP_IMP_FULL_DATABASE",
+    "DATAPUMP_CLOUD_EXP",
+    "DATAPUMP_CLOUD_IMP",
     "DBA",
     "DELETE_CATALOG_ROLE",
+    "DV_ACCTMGR",
+    "DV_ADMIN",
+    "DV_MONITOR",
+    "EM_EXPRESS_ALL",
+    "EM_EXPRESS_BASIC",
     "EXECUTE_CATALOG_ROLE",
     "EXP_FULL_DATABASE",
     "GATHER_SYSTEM_STATISTICS",
+    "GGSYS_ROLE",
+    "GSMADMIN_ROLE",
     "HS_ADMIN_EXECUTE_ROLE",
     "HS_ADMIN_ROLE",
     "HS_ADMIN_SELECT_ROLE",
@@ -77,12 +89,22 @@ FALLBACK_SYSTEM_ROLE_NAMES: Set[str] = {
     "JAVAIDPRIV",
     "JAVASYSPRIV",
     "JAVAUSERPRIV",
+    "LOGSTDBY_ADMINISTRATOR",
     "OEM_ADVISOR",
     "OEM_MONITOR",
+    "OLAP_DBA",
+    "OLAP_USER",
+    "OLAP_XS_ADMIN",
+    "PDB_DBA",
     "RECOVERY_CATALOG_OWNER",
+    "RFS_ADMIN",
     "RESOURCE",
     "SCHEDULER_ADMIN",
     "SELECT_CATALOG_ROLE",
+    "SODA_APP",
+    "WM_ADMIN_ROLE",
+    "XDBADMIN",
+    "XDB_SET_INVOKER",
 }
 
 

--- a/readme_config.txt
+++ b/readme_config.txt
@@ -1,5 +1,5 @@
 配置说明 (config.ini)
-版本：0.9.9.3（更新日期：2026-04-14）
+版本：0.9.9.4（更新日期：2026-04-17）
 本文件为完整配置说明书，覆盖所有可配置项（含最近新增功能）。
 
 通用约定
@@ -33,7 +33,7 @@
 - port：源端 OceanBase 端口（必填）。
 - user_string：源端完整的 obclient -u 参数（必填）。
 - password：源端 OceanBase 密码（必填）。
-- 说明：仅在 `source_db_mode=oceanbase` 时使用；当前已支持 compare 与 certified fixup family，grant/Oracle blacklist/source usability 等未认证能力仍会门控关闭或转 deferred/manual。
+- 说明：仅在 `source_db_mode=oceanbase` 时使用；当前已支持 compare、grants、scope/cutoff、source usability、table presence 与 certified fixup family；Oracle blacklist 语义仅保留诊断提示，不进入 OB source 主链路。
 - 说明：当前 OB source adapter 主要覆盖 table/view-based metadata；`DATABASE/SCHEMA` 级非表触发器暂不纳入 `source_db_mode=oceanbase` 的 compare/fixup。
 
 4) [SETTINGS]
@@ -42,23 +42,26 @@
 - source_db_mode：源端数据库类型。默认：oracle。
   可选值：oracle、oceanbase。
   说明：`oracle` 保持现有 Oracle->OceanBase 路径；`oceanbase` 启用 OceanBase Oracle-mode source -> OceanBase target。
-  说明：`oceanbase` 模式默认保持严格 OB->OB compare，并允许 certified fixup family；`generate_grants` 仍会自动关闭，未认证 family 会在报告和 fixup 输出中显式标成 deferred/manual。
+  说明：`oceanbase` 模式默认保持严格 OB->OB compare，并允许 certified fixup family；`generate_grants`、`object_created_before`、`check_object_usability`、`table_data_presence_check`、`source_object_scope_mode=explicit_roots/remap_root_closure` 都按产品模式生效。
 - source_schemas：源端 schema 列表（必填）。默认：无；为空将直接退出。
   说明：逗号分隔，大小写不敏感；只扫描这些 schema 的对象与依赖。
   说明：它只定义“源端扫描范围”，不等于目标端受管 schema。
   说明：目标端实际受管范围会按 remap/full mapping 自动推导；即使 remap 到 config.ini 中未出现的新目标 schema，也会继续进入 compare/fixup/report。
 - remap_file：Remap 规则文件路径。默认：空（按 1:1 映射）。
 - source_object_scope_mode：源对象范围模式。默认：full_source。
-  可选值：full_source、remap_root_closure。
-  说明：`full_source` 保持当前行为，按 `source_schemas` 全量扫描；`remap_root_closure` 仅以 `remap_file` 中显式 TABLE/VIEW 为 root seeds，再按依赖、反向依赖、附属关系扩展闭包，不在闭包中的对象（及其相关 INDEX/CONSTRAINT/SYNONYM/SEQUENCE 等）整体忽略。
-  说明：当设置为 `remap_root_closure` 且配置了 `trigger_list` 时，`trigger_list` 中的触发器会作为显式 keep set 保留；`trigger_list` 支持填写源端触发器名，或 remap 后的目标触发器名。
-  说明：`missed_tables_views_for_OMS/` 与 report_db 的 `OMS_MISSING` 在该模式下默认只导出 `remap_file` 中显式 TABLE/VIEW roots，不再把 closure 依赖对象一起带出。
+  可选值：full_source、explicit_roots、remap_root_closure。
+  说明：`full_source` 保持当前行为，按 `source_schemas` 全量扫描。
+  说明：`explicit_roots` 仅保留 `remap_file` 中显式 TABLE/VIEW roots 及其附属对象，不做依赖闭包扩展。
+  说明：`remap_root_closure` 以 `remap_file` 中显式 TABLE/VIEW 为 root seeds，再按依赖、反向依赖、附属关系扩展闭包，不在闭包中的对象（及其相关 INDEX/CONSTRAINT/SYNONYM/SEQUENCE 等）整体忽略。
+  说明：当设置为 `explicit_roots` 或 `remap_root_closure` 且配置了 `trigger_list` 时，`trigger_list` 中的触发器会作为显式 keep set 保留；`trigger_list` 支持填写源端触发器名，或 remap 后的目标触发器名。
+  说明：`missed_tables_views_for_OMS/` 与 report_db 的 `OMS_MISSING` 在两种 scoped 模式下默认都只导出 `remap_file` 中显式 TABLE/VIEW roots，不再把依赖扩展对象一起带出。
   说明：该模式下 `object_mapping_<ts>.txt` 表示本轮 managed mapping；若 closure 内还发现了未进入 operator-facing compare/fixup 的 related object，会额外输出 `object_mapping_discovery_<ts>.txt`。
   说明：若 `trigger_list` 非法或未启用 `TRIGGER` 检查，程序会 fail-fast；若个别条目无法在源端或显式 remap 规则中解析，程序不再中止，而是把这些条目写入 `source_scope_detail_<ts>.txt` / `trigger_status_report.txt`，并从本轮 scoped closure 与 fixup 中排除。
 - remap_scope_text_fallback_mode：scoped 文本补盲模式。默认：off。
   可选值：off、safe。
   说明：`off` 仅使用结构化路径（依赖/反向依赖/附属对象/配对对象）扩展 closure；`safe` 会对结构化闭包之外的剩余对象，从 `DBA_SOURCE`、`DBA_VIEWS.TEXT`、`DBA_MVIEWS.QUERY`、scheduler/job 文本等受控来源做补盲，并以 `TEXT_REFERENCE_HEURISTIC` 写入 `source_scope_detail_<ts>.txt`。
   说明：`safe` 额外支持受控 dynamic SQL（`EXECUTE IMMEDIATE`/`DBMS_SQL.PARSE`）、纯字符串拼接 SQL，以及同 schema 未带前缀的 package/procedure/function 调用；普通字符串字面量和跨 schema 未带前缀引用仍不会被猜测。
+  说明：`safe` 还会识别源码中的静态 `DBMS_SCHEDULER.CREATE_JOB/CREATE_SCHEDULE` 名称，把命中的 JOB/SCHEDULE 纳入 closure；若 `job_name/schedule_name` 为变量或无法静态折叠，会在 `source_scope_detail_<ts>.txt` 中以 `SCHEDULER_CREATE_AMBIGUOUS` / `SCHEDULER_CREATE_TARGET_UNRESOLVED` 输出，供人工复核。
   说明：变量拼接 SQL 不会自动纳入 closure；会在 `source_scope_detail_<ts>.txt` 中以 `TEXT_REFERENCE_AMBIGUOUS` 输出，供人工复核。
   说明：`safe` 不会对全 schema 对象 DDL 做 `DBMS_METADATA` 全量 grep。
   说明：生产大库下 `JOB_ACTION` 与 scoped text matching 带有保护性上限；若发生超大文本跳过/高扇出跳过/递归封顶，会生成 `runtime_degraded_detail_<ts>.txt` 并在主报告提示本轮 compare 是否完整。
@@ -102,6 +105,7 @@
   说明：若本轮命中了性能保护或大图保护，还会额外输出 `runtime_degraded_detail_<ts>.txt`；其中 `COMPARE` 级事件代表当前结果不应直接作为最终 compare 结论。
 - report_to_db：是否将报告存储到 OceanBase（obclient 方式）。默认：false。
   说明：开启后仍会保留本地文本报告，写库失败时是否中断由 report_db_fail_abort 控制。
+  说明：若配置里省略该项，运行时会显式提示“当前按 false 处理”；依赖 report_db 的环境建议在 `config.ini` 中明确写出 `report_to_db=true/false`，避免升级歧义。
   说明：写库采用发布门禁；DIFF_REPORT_SUMMARY.WRITE_STATUS=READY 才表示可用于正式排查（WRITING/FAILED 为未完成或失败）。
   说明：开启后会在 run 目录输出 report_sql_<timestamp>.txt（仅写入 report_id 与 HOW TO 入口，不再内嵌 HOW TO 正文），并尝试创建只读分析视图（actions/profile/trends/pending/grant/usability）。
   说明：当 report_db_store_scope=full 时，会将 run 目录下所有 txt 逐行写入 DIFF_REPORT_ARTIFACT_LINE，实现 txt 内容 100% 可查询覆盖。
@@ -229,6 +233,7 @@
 黑名单（不支持表过滤）
 - blacklist_mode：黑名单来源模式。默认：auto。
   可选值：auto（TMP_BLACK_TABLE + 规则文件）、table_only、rules_only、disabled。
+  说明：该能力面向 Oracle source；`source_db_mode=oceanbase` 下仅保留诊断提示，不进入 OB source compare/fixup 主链路。
 - blacklist_rules_path：黑名单规则 JSON 路径。默认：blacklist_rules.json（内置规则）。
   注意：blacklist_mode=auto/rules_only 时需确保该文件随工具部署，否则规则将被跳过。
   规则文件说明：每条 rule 使用 `enabled`（true/false）控制是否启用；程序兼容旧 `tag`（enabled/disabled）字段。运行时还会叠加 blacklist_rules_enable / blacklist_rules_disable。
@@ -260,8 +265,10 @@
   可选值：auto（OB>=4.4.2 开启校验+修补；低版本仅打印）、on（强制开启校验+修补）、off（强制仅打印）。
   说明：当 mode=auto 且 OB 版本无法识别时，为兼容旧行为会回退为“仅打印”并在日志提示。
 - gtt_table_handling_mode：Oracle 全局临时表（GTT）处理模式。默认：rewrite_to_normal。
-  可选值：rewrite_to_normal、preserve_original、blocked。
+  可选值：rewrite_to_normal、preserve_original、blocked、auto。
   说明：`rewrite_to_normal` 会把源端 GTT 当作受管 TABLE，并在 fixup 中生成普通 TABLE DDL；`preserve_original` 仍纳入正常 compare/fixup，但保留 Oracle GTT 语义原样输出；`blocked` 保持旧行为，继续进入 unsupported/temporary 路径。
+  说明：`auto` 会按目标 OceanBase 版本自动决策：满足原生 GTT 条件时切换到 `preserve_original`，否则保守回退 `rewrite_to_normal`；若显式指定 `preserve_original` 但目标版本不支持，会在运行时降级为 `blocked` 并给出提示。
+  说明：`rewrite_to_normal` 会丢失 `ON COMMIT DELETE/PRESERVE ROWS` 的事务清理语义；主报告、运行时 notice、`manual_actions_required_<ts>.txt` 与脚本头注释都会显式提醒，需人工确认后再执行。
   说明：当 GTT 处于 `rewrite_to_normal/preserve_original` 模式时，结构会进入正常 compare/fixup，但不会进入 `missed_tables_views_for_OMS/` 或 report_db `OMS_MISSING`，因为它们属于“结构迁移、不做数据迁移”。
 - generate_extra_cleanup：是否生成“目标端多余对象”的清理候选。默认：true。
   说明：普通候选会以注释形式输出到 `fixup_scripts/cleanup_candidates/extra_cleanup_candidates.txt`，不会被 run_fixup 自动执行；用于人工审核后再处理。
@@ -305,6 +312,8 @@
 - job_schedule_fixup_mode：JOB/SCHEDULE 修补模式。默认：manual。
   可选值：manual（保持人工处理，不生成缺失脚本）、semi_auto（当源端 DDL 缺失时输出草案模板到 `fixup_scripts/unsupported/job|schedule/`）。
   说明：semi_auto 仅提供人工补录模板，不改变 JOB/SCHEDULE 的“不支持自动修补”统计口径。
+  说明：`run_fixup.py` 默认也会跳过 `fixup_scripts/job/` 与 `fixup_scripts/schedule/`；需人工核对后显式 `--only-dirs job` / `--only-dirs schedule`。
+  说明：即便显式配合 `--iterative`，JOB/SCHEDULE 失败后也只保留在 `errors/fixup_errors_<ts>.txt`，不会跨轮自动重试。
 - plain_not_null_fixup_mode：普通 `NULLABLE -> NOT NULL` 收紧输出模式。默认：runnable_if_no_nulls。
   可选值：
   review_only（保持 `table_alter` 中的 review-first 注释）、
@@ -322,7 +331,7 @@
 授权与权限脚本
 - generate_grants：是否生成授权脚本并附加到修补 DDL。默认：true。
   注意：generate_grants 仅控制授权脚本与注入，修补脚本仍由 generate_fixup 控制。
-  说明：`source_db_mode=oceanbase` 下当前会自动关闭，并在报告中标记为 deferred。
+  说明：`source_db_mode=oceanbase` 下会按 OB source inventory 正常生成 role/system/object/column privilege 缺失授权，并保留 `ADMIN OPTION` / `WITH GRANT OPTION` 语义。
   说明：当目标对象当前不存在且本轮不会创建时，授权会延后到 `fixup_scripts/grants_deferred/`，
   同时写入 `deferred_grants_detail_<ts>.txt`，避免误执行失败。
   说明：若延后授权因 owner 策略无法自动输出 SQL，`fixup_scripts/grants_deferred/README.txt` 仍会保留完整提醒。
@@ -388,8 +397,10 @@
 - synonym_check_scope：同义词校验范围。默认：Oracle 源 `public_only`，OceanBase 源 `all`。
   可选值：public_only（仅 PUBLIC 参与 missing/extra/汇总统计）、all（PUBLIC+私有全量校验）。
   说明：该开关影响“校验与统计口径”；不影响同义词 fixup 输出范围。PUBLIC 同义词仅在终点对象落入受管源范围时才会被纳入，Oracle 自带系统 PUBLIC 链路会自动过滤。
+  说明：当 `source_db_mode=oceanbase` 且配置中省略该项时，运行时会显式提示“当前默认按 all 处理”；如需锁定旧行为，建议在 `config.ini` 中明确写出。
 - synonym_fixup_scope：同义词修补范围。默认：Oracle 源 `public_only`，OceanBase 源 `all`。
   可选值：all（PUBLIC+私有）、public_only（仅 PUBLIC）。
+  说明：当 `source_db_mode=oceanbase` 且配置中省略该项时，运行时会显式提示“当前默认按 all 处理”；如需锁定旧行为，建议在 `config.ini` 中明确写出。
 - name_collision_mode：约束/索引重名处理模式。默认：fixup。
   可选值：off（关闭）、report（仅输出重名诊断，不改写脚本）、fixup（生成重名修复脚本并改写缺失 INDEX/CONSTRAINT 名称）。
 - name_collision_rename_existing：fixup 模式下是否重命名目标端已有冲突对象。默认：true。
@@ -397,7 +408,7 @@
   兼容说明：若检测到目标 OB 版本不支持 `ALTER TABLE ... RENAME CONSTRAINT`，系统会自动改用约束 `DROP + ADD` 路径，仅索引继续使用 RENAME。
 - trigger_list：触发器清单文件（每行 SCHEMA.TRIGGER_NAME）。默认：空。
   注意：配置后仅生成列表内触发器，并输出 trigger_status_report.txt 报告；清单读取失败会回退全量触发器。
-  说明：在 `source_object_scope_mode=remap_root_closure` 下，`trigger_list` 同时支持源端名和 remap 后目标名；若目标名能通过显式 remap 反查到源端触发器，会按该源端触发器继续 compare/fixup。
+  说明：在 `source_object_scope_mode=explicit_roots/remap_root_closure` 下，`trigger_list` 同时支持源端名和 remap 后目标名；若目标名能通过显式 remap 反查到源端触发器，会按该源端触发器继续 compare/fixup。
   说明：若清单中的触发器属于非表触发器（如 `BEFORE DROP ON DATABASE` 或 `INSTEAD OF ... ON VIEW`），程序不会生成普通 trigger DDL，
   对 `DATABASE/SCHEMA` 级事件触发器，会在 `trigger_status_report.txt` 中标成 `NON_TABLE_SOURCE_TRIGGER`，并额外输出 `triggers_non_table_detail_<ts>.txt` 与人工处理清单；`INSTEAD OF ... ON VIEW` 会按普通触发器参与 compare/fixup。
   说明：若清单命中的缺失触发器依赖的目标 TABLE/VIEW 仍不存在，本轮不会生成 trigger DDL；会在 `fixup_skip_summary_<ts>.txt` 中记录 `base_table_missing` 或同类跳过原因，待依赖对象补齐后 rerun 再生成 trigger 脚本。

--- a/run_fixup.py
+++ b/run_fixup.py
@@ -62,7 +62,7 @@ try:
 except Exception:  # pragma: no cover - non-POSIX fallback
     fcntl = None
 
-__version__ = "0.9.9.3"
+__version__ = "0.9.9.4"
 
 CONFIG_DEFAULT_PATH = "config.ini"
 DEFAULT_FIXUP_DIR = "fixup_scripts"
@@ -86,6 +86,71 @@ NOTICE_STATE_FILENAME = ".comparator_notice_state.json"
 NOTICE_STATE_SCHEMA_VERSION = 1
 MANUAL_ACTION_REPORT_KIND = "MANUAL_ACTION_REQUIRED"
 MANUAL_ACTION_REPORT_SCHEMA_VERSION = 1
+MANUAL_REVIEW_DIRS = ("materialized_view", "job", "schedule")
+FIXUP_SUPPORT_TIER_CERTIFIED = "certified"
+FIXUP_SUPPORT_TIER_PREVIEW = "preview"
+FIXUP_SUPPORT_TIER_MANUAL_ONLY = "manual-only"
+FIXUP_SUPPORT_TIER_UNSUPPORTED = "unsupported"
+FIXUP_RETRY_POLICY_ITERATIVE = "iterative-retry"
+FIXUP_RETRY_POLICY_NO_ITERATIVE = "no-iterative-retry"
+FIXUP_FAMILY_EXECUTION_CONTRACTS: Dict[str, Dict[str, object]] = {
+    "materialized_view": {
+        "family": "MATERIALIZED VIEW",
+        "support_tier": FIXUP_SUPPORT_TIER_MANUAL_ONLY,
+        "retry_policy": FIXUP_RETRY_POLICY_NO_ITERATIVE,
+        "iterative_retry": False,
+        "note": "manual-only family，需人工核对后单次执行。",
+    },
+    "job": {
+        "family": "JOB",
+        "support_tier": FIXUP_SUPPORT_TIER_MANUAL_ONLY,
+        "retry_policy": FIXUP_RETRY_POLICY_NO_ITERATIVE,
+        "iterative_retry": False,
+        "note": "manual-only family，需人工核对后单次执行。",
+    },
+    "schedule": {
+        "family": "SCHEDULE",
+        "support_tier": FIXUP_SUPPORT_TIER_MANUAL_ONLY,
+        "retry_policy": FIXUP_RETRY_POLICY_NO_ITERATIVE,
+        "iterative_retry": False,
+        "note": "manual-only family，需人工核对后单次执行。",
+    },
+    "sequence_restart": {
+        "family": "SEQUENCE RESTART",
+        "support_tier": FIXUP_SUPPORT_TIER_MANUAL_ONLY,
+        "retry_policy": FIXUP_RETRY_POLICY_NO_ITERATIVE,
+        "iterative_retry": False,
+        "note": "值同步 SQL，失败后应先核对源/目标 LAST_NUMBER。",
+    },
+    "cleanup_safe": {
+        "family": "CLEANUP SAFE",
+        "support_tier": FIXUP_SUPPORT_TIER_MANUAL_ONLY,
+        "retry_policy": FIXUP_RETRY_POLICY_NO_ITERATIVE,
+        "iterative_retry": False,
+        "note": "destructive 清理 SQL，失败后需人工确认。",
+    },
+    "cleanup_semantic": {
+        "family": "CLEANUP SEMANTIC",
+        "support_tier": FIXUP_SUPPORT_TIER_MANUAL_ONLY,
+        "retry_policy": FIXUP_RETRY_POLICY_NO_ITERATIVE,
+        "iterative_retry": False,
+        "note": "语义级 destructive 清理 SQL，失败后需人工确认。",
+    },
+    "tables_unsupported": {
+        "family": "TABLE",
+        "support_tier": FIXUP_SUPPORT_TIER_UNSUPPORTED,
+        "retry_policy": FIXUP_RETRY_POLICY_NO_ITERATIVE,
+        "iterative_retry": False,
+        "note": "缺少高保真 DDL，仅输出占位脚本。",
+    },
+    "unsupported": {
+        "family": "UNSUPPORTED",
+        "support_tier": FIXUP_SUPPORT_TIER_UNSUPPORTED,
+        "retry_policy": FIXUP_RETRY_POLICY_NO_ITERATIVE,
+        "iterative_retry": False,
+        "note": "仅输出 unsupported 草案，不纳入自动重试。",
+    },
+}
 
 class RuntimeNotice(NamedTuple):
     notice_id: str
@@ -104,6 +169,58 @@ class ManualActionNoticeRow(NamedTuple):
     related_fixup_dir: str
     why: str
     recommended_action: str
+
+
+def normalize_contract_dir_name(path_value: Union[Path, str, None]) -> str:
+    if path_value is None:
+        return ""
+    raw = str(path_value).strip()
+    if not raw:
+        return ""
+    parts = Path(raw).parts
+    if not parts:
+        return normalize_dir_filter(raw.split("/", 1)[0])
+    head = normalize_dir_filter(parts[0])
+    known_heads = set(FIXUP_FAMILY_EXECUTION_CONTRACTS.keys()) | set(DIR_OBJECT_TYPE_MAP.keys()) | set(GRANT_DIRS)
+    if head in known_heads:
+        return head
+    if head in {DEFAULT_FIXUP_DIR, DONE_DIR_NAME} and len(parts) > 1:
+        return normalize_dir_filter(parts[1])
+    if len(parts) > 1:
+        second = normalize_dir_filter(parts[1])
+        if second:
+            return second
+    return head
+
+
+def build_default_family_label(dir_name: str) -> str:
+    if not dir_name:
+        return "-"
+    mapped = DIR_OBJECT_TYPE_MAP.get(dir_name)
+    if mapped:
+        return mapped
+    return dir_name.replace("_", " ").upper()
+
+
+def get_fixup_execution_contract(path_value: Union[Path, str, None]) -> Dict[str, object]:
+    dir_name = normalize_contract_dir_name(path_value)
+    contract = FIXUP_FAMILY_EXECUTION_CONTRACTS.get(dir_name)
+    if contract is not None:
+        resolved = dict(contract)
+        resolved.setdefault("family", build_default_family_label(dir_name))
+        resolved.setdefault("support_tier", FIXUP_SUPPORT_TIER_CERTIFIED)
+        resolved.setdefault("retry_policy", FIXUP_RETRY_POLICY_ITERATIVE)
+        resolved.setdefault("iterative_retry", True)
+        resolved["dir_name"] = dir_name
+        return resolved
+    return {
+        "dir_name": dir_name,
+        "family": build_default_family_label(dir_name),
+        "support_tier": FIXUP_SUPPORT_TIER_CERTIFIED if dir_name else "-",
+        "retry_policy": FIXUP_RETRY_POLICY_ITERATIVE if dir_name else "-",
+        "iterative_retry": True,
+        "note": "",
+    }
 
 
 def resolve_notice_state_path(config_dir: Optional[Union[str, Path]]) -> Path:
@@ -872,18 +989,20 @@ DEPENDENCY_LAYERS = [
     ["table"],                                       # Layer 2: Base tables
     ["table_alter"],                                 # Layer 3: Table modifications
     ["view_prereq_grants", "grants"],                # Layer 4: View prereq + general grants
-    ["view", "view_refresh", "synonym"],             # Layer 5: View create/refresh + simple dependent objects
-    ["view_post_grants"],                            # Layer 6: View post grants
-    ["materialized_view"],                           # Layer 7: MVIEWs
-    ["type"],                                        # Layer 8: Types (specs)
-    ["package"],                                     # Layer 9: Package specs
-    ["procedure", "function"],                       # Layer 10: Standalone routines
-    ["type_body", "package_body"],                   # Layer 11: Type/package bodies
-    ["context"],                                     # Layer 12: Application contexts
-    ["name_collision"],                              # Layer 13: Name collision remediation
-    ["constraint", "index"],                         # Layer 14: Constraints and indexes
-    ["trigger"],                                     # Layer 15: Triggers (last)
-    ["job", "schedule"],                             # Layer 16: Jobs
+    ["synonym"],                                     # Layer 5: Synonyms
+    ["view_refresh"],                                # Layer 6: Existing prerequisite views
+    ["view"],                                        # Layer 7: Missing views
+    ["view_post_grants"],                            # Layer 8: View post grants
+    ["materialized_view"],                           # Layer 9: MVIEWs
+    ["type"],                                        # Layer 10: Types (specs)
+    ["package"],                                     # Layer 11: Package specs
+    ["procedure", "function"],                       # Layer 12: Standalone routines
+    ["type_body", "package_body"],                   # Layer 13: Type/package bodies
+    ["context"],                                     # Layer 14: Application contexts
+    ["name_collision"],                              # Layer 15: Name collision remediation
+    ["constraint", "index"],                         # Layer 16: Constraints and indexes
+    ["trigger"],                                     # Layer 17: Triggers (last)
+    ["job", "schedule"],                             # Layer 18: Jobs
 ]
 
 CORE_GRANT_DIRS_ORDER = ("grants_all", "grants_miss", "grants")
@@ -1061,6 +1180,10 @@ def build_run_fixup_change_notices(
     selected_grants_revoke = any(dir_filter_overlaps("grants_revoke", item) for item in selected_dirs)
     selected_cleanup_safe = any(dir_filter_overlaps("cleanup_safe", item) for item in selected_dirs)
     selected_sequence_restart = any(dir_filter_overlaps("sequence_restart", item) for item in selected_dirs)
+    selected_manual_review = any(
+        any(dir_filter_overlaps(dir_name, item) for item in selected_dirs)
+        for dir_name in MANUAL_REVIEW_DIRS
+    )
     if not getattr(args, "allow_table_create", False) and (
         selected_table or (selected_all and (fixup_dir / "table").exists())
     ):
@@ -1101,6 +1224,22 @@ def build_run_fixup_change_notices(
             "0.9.8.9",
             "sequence_restart 默认不自动执行",
             "sequence_restart/ 是值同步 SQL；请先核对 sequence_restart_detail 与源/目标 LAST_NUMBER，再显式按目录执行。",
+        ))
+    manual_dirs_present = [
+        dir_name for dir_name in MANUAL_REVIEW_DIRS
+        if (fixup_dir / dir_name).exists()
+    ]
+    if manual_dirs_present and (selected_all or selected_manual_review):
+        iterative_hint = ""
+        if getattr(args, "iterative", False):
+            iterative_hint = " 如启用 --iterative，失败脚本也只保留到 errors 报告，不会自动重试。"
+        notices.append(RuntimeNotice(
+            "manual_only_family_review",
+            "0.9.9.4",
+            "manual-only family 默认不自动执行",
+            "、".join(manual_dirs_present)
+            + "/ 属于 manual-only family；请先核对 manual_actions_required 与源端定义，再显式按目录执行。"
+            + iterative_hint,
         ))
     return notices
 
@@ -1231,8 +1370,10 @@ class FixupStateLedger:
         self._load()
 
     @staticmethod
-    def fingerprint(sql_text: str) -> str:
-        return hashlib.sha1((sql_text or "").encode("utf-8")).hexdigest()
+    def fingerprint(sql_payload: Union[str, bytes]) -> str:
+        if isinstance(sql_payload, bytes):
+            return hashlib.sha1(sql_payload).hexdigest()
+        return hashlib.sha1((sql_payload or "").encode("utf-8")).hexdigest()
 
     def _load(self) -> None:
         if not self.path.exists():
@@ -1296,16 +1437,20 @@ class FixupStateLedger:
             self._dirty = True
 
 
-def read_sql_text_with_limit(sql_path: Path, max_bytes: Optional[int]) -> Tuple[Optional[str], Optional[str]]:
+def read_sql_text_with_limit(sql_path: Path, max_bytes: Optional[int]) -> Tuple[Optional[str], Optional[bytes], Optional[str]]:
     """Read SQL file with optional size limit."""
     try:
         if max_bytes and max_bytes > 0:
             size = sql_path.stat().st_size
             if size > max_bytes:
-                return None, f"文件过大 ({size} bytes) 超过限制 {max_bytes} bytes"
-        return sql_path.read_text(encoding="utf-8", errors="replace"), None
+                return None, None, f"文件过大 ({size} bytes) 超过限制 {max_bytes} bytes"
+        raw_bytes = sql_path.read_bytes()
+        try:
+            return raw_bytes.decode("utf-8"), raw_bytes, None
+        except UnicodeDecodeError as exc:
+            return None, raw_bytes, f"文件编码不是 UTF-8，已阻断执行以避免破坏 replay/ledger 语义: {exc}"
     except Exception as exc:
-        return None, f"读取文件失败: {exc}"
+        return None, None, f"读取文件失败: {exc}"
 
 
 def extract_sql_error(output: str) -> Optional[str]:
@@ -1624,6 +1769,9 @@ class ErrorReportEntry:
     error_code: str
     object_name: str
     message: str
+    family: str = "-"
+    support_tier: str = "-"
+    retry_policy: str = "-"
 
 
 @dataclass
@@ -2117,7 +2265,7 @@ def load_ob_config(config_path: Path) -> Tuple[Dict[str, str], Path, Path, str, 
 
     if source_db_mode == "oceanbase":
         log.info(
-            "source_db_mode=oceanbase：run_fixup 执行语义保持不变；unsupported/、grants_deferred/、cleanup_safe/cleanup_semantic 仍默认不会自动执行。"
+            "source_db_mode=oceanbase：run_fixup 执行语义保持不变；unsupported/、grants_deferred/、cleanup_safe/cleanup_semantic、materialized_view/job/schedule 仍默认不会自动执行，manual-only family 即便显式配合 --iterative 也不会跨轮自动重试。"
         )
 
     report_dir = parser.get("SETTINGS", "report_dir", fallback="main_reports").strip() or "main_reports"
@@ -2288,7 +2436,7 @@ def collect_sql_files_by_layer(
         # Keep non-smart execution order aligned with dependency-aware layers.
         priority = [
             "sequence", "sequence_restart", "table", "table_alter", "view_prereq_grants", "grants",
-            "view", "view_refresh", "synonym", "view_post_grants", "materialized_view",
+            "synonym", "view_refresh", "view", "view_post_grants", "materialized_view",
             "type", "package", "procedure", "function",
             "type_body", "package_body", "context", "name_collision", "constraint", "index", "trigger",
             "job", "schedule",
@@ -2565,6 +2713,13 @@ def extract_execution_error(result: subprocess.CompletedProcess) -> Optional[str
     if stdout_error:
         return stdout_error
     if result.returncode != 0:
+        combined_lines = [
+            line.strip()
+            for line in ((result.stderr or "") + "\n" + (result.stdout or "")).splitlines()
+            if line.strip()
+        ]
+        if combined_lines:
+            return combined_lines[-1]
         stderr = (result.stderr or "").strip()
         return stderr or "执行失败"
     return None
@@ -3793,7 +3948,7 @@ def build_view_chain_plan(
             plan_lines.append(f"BLOCK: 缺少 DDL for {dep_full}({dep_type})")
             blocked = True
             continue
-        ddl_text, ddl_error = read_sql_text_with_limit(ddl_path, max_sql_file_bytes)
+        ddl_text, _ddl_bytes, ddl_error = read_sql_text_with_limit(ddl_path, max_sql_file_bytes)
         if ddl_error:
             plan_lines.append(f"BLOCK: 读取 DDL 失败 {ddl_path} ({ddl_error})")
             blocked = True
@@ -4096,9 +4251,7 @@ def execute_sql_statements(
 
     current_schema: Optional[str] = None
 
-    for idx, statement in enumerate(statements, start=1):
-        if not statement.strip():
-            continue
+    for idx, statement in enumerate(effective_statements, start=1):
         match = CURRENT_SCHEMA_PATTERN.match(statement.strip())
         if match:
             current_schema = match.group("schema")
@@ -4110,6 +4263,14 @@ def execute_sql_statements(
         except subprocess.TimeoutExpired:
             timeout_label = "no-timeout" if timeout is None else f"> {timeout} 秒"
             failures.append(StatementFailure(idx, f"执行超时 ({timeout_label})", statement_to_run))
+            for remainder_idx, remainder_statement in enumerate(effective_statements[idx:], start=idx + 1):
+                failures.append(
+                    StatementFailure(
+                        remainder_idx,
+                        "前置语句超时未执行",
+                        remainder_statement,
+                    )
+                )
             break
 
         error_msg = extract_execution_error(result)
@@ -4898,6 +5059,7 @@ def record_error_entry(
         return False
     error_code = parse_error_code(error_message)
     object_name = infer_error_object(statement, relative_path)
+    contract = get_fixup_execution_contract(relative_path)
     message = " ".join((error_message or "").split())
     if len(message) > 200:
         message = message[:200] + "..."
@@ -4907,7 +5069,10 @@ def record_error_entry(
             statement_index=statement_index,
             error_code=error_code,
             object_name=object_name,
-            message=message or "-"
+            message=message or "-",
+            family=str(contract.get("family") or "-"),
+            support_tier=str(contract.get("support_tier") or "-"),
+            retry_policy=str(contract.get("retry_policy") or "-"),
         )
     )
     return True
@@ -4928,11 +5093,12 @@ def write_error_report(
     lines = [
         "# fixup error report",
         f"# count={len(entries)} limit={limit} truncated={'true' if truncated else 'false'}",
-        "FILE | STMT_INDEX | ERROR_CODE | OBJECT | MESSAGE"
+        "FILE | STMT_INDEX | ERROR_CODE | OBJECT | FAMILY | SUPPORT_TIER | RETRY_POLICY | MESSAGE"
     ]
     for entry in entries:
         lines.append(
-            f"{entry.file_path} | {entry.statement_index} | {entry.error_code} | {entry.object_name} | {entry.message}"
+            f"{entry.file_path} | {entry.statement_index} | {entry.error_code} | {entry.object_name} | "
+            f"{entry.family} | {entry.support_tier} | {entry.retry_policy} | {entry.message}"
         )
     if truncated:
         lines.append("[... TRUNCATED ...]")
@@ -4954,6 +5120,16 @@ def normalize_failed_path(path: Path, repo_root: Path) -> Path:
         return repo_root / raw
 
 
+def build_non_retryable_iterative_message(relative_path: Path) -> str:
+    contract = get_fixup_execution_contract(relative_path)
+    return (
+        f"family={contract.get('family') or '-'}, "
+        f"support_tier={contract.get('support_tier') or '-'}, "
+        f"retry_policy={contract.get('retry_policy') or '-'}；"
+        "上一轮失败后本轮不自动重试"
+    )
+
+
 def execute_grant_file_with_prune(
     obclient_cmd: List[str],
     sql_path: Path,
@@ -4968,13 +5144,13 @@ def execute_grant_file_with_prune(
     state_ledger: Optional[FixupStateLedger] = None
 ) -> Tuple[ScriptResult, ExecutionSummary, int, int, bool]:
     relative_path = sql_path.relative_to(repo_root)
-    sql_text, read_error = read_sql_text_with_limit(sql_path, max_sql_file_bytes)
+    sql_text, sql_bytes, read_error = read_sql_text_with_limit(sql_path, max_sql_file_bytes)
     if read_error:
         msg = read_error
         log.error("%s %s -> ERROR (%s)", label_prefix, relative_path, msg)
         failure = StatementFailure(0, msg, "")
         return ScriptResult(relative_path, "ERROR", msg, layer), ExecutionSummary(0, [failure]), 0, 0, False
-    fingerprint = FixupStateLedger.fingerprint(sql_text or "")
+    fingerprint = FixupStateLedger.fingerprint(sql_bytes or b"")
     if state_ledger and state_ledger.is_completed(relative_path, fingerprint):
         msg = "状态账本命中，跳过重复执行"
         log.warning("%s %s -> SKIP (%s)", label_prefix, relative_path, msg)
@@ -5107,12 +5283,12 @@ def execute_script_with_summary(
     exec_stats: Optional[Dict[str, int]] = None,
 ) -> Tuple[ScriptResult, ExecutionSummary]:
     relative_path = sql_path.relative_to(repo_root)
-    sql_text, read_error = read_sql_text_with_limit(sql_path, max_sql_file_bytes)
+    sql_text, sql_bytes, read_error = read_sql_text_with_limit(sql_path, max_sql_file_bytes)
     if read_error:
         msg = read_error
         log.error("%s %s -> ERROR (%s)", label_prefix, relative_path, msg)
         return ScriptResult(relative_path, "ERROR", msg, layer), ExecutionSummary(0, [StatementFailure(0, msg, "")])
-    fingerprint = FixupStateLedger.fingerprint(sql_text or "")
+    fingerprint = FixupStateLedger.fingerprint(sql_bytes or b"")
     if state_ledger and state_ledger.is_completed(relative_path, fingerprint):
         msg = "状态账本命中，跳过重复执行"
         log.warning("%s %s -> SKIP (%s)", label_prefix, relative_path, msg)
@@ -5366,6 +5542,7 @@ def parse_args() -> argparse.Namespace:
           --view-chain-autofix : 基于 VIEW 依赖链生成/执行修复计划
           --allow-table-create : 允许执行 table/ 建表脚本（默认关闭，防止误建空表）
           注意: grants_deferred/ 默认跳过，需在补齐对象后显式执行
+          注意: materialized_view/job/schedule 默认跳过，需核对后显式执行；即便显式配合 --iterative 也不会跨轮自动重试
         
         保留原有功能：
           --only-dirs    : 按子目录过滤
@@ -5529,7 +5706,16 @@ def main() -> None:
         only_dirs = [normalize_dir_filter(d) for d in only_dirs] if only_dirs else []
     
     exclude_dirs = [normalize_dir_filter(d) for d in exclude_dirs]
-    default_excludes = {"tables_unsupported", "unsupported", "constraint_validate_later", "grants_deferred", "cleanup_safe", "cleanup_semantic", "sequence_restart"}
+    default_excludes = {
+        "tables_unsupported",
+        "unsupported",
+        "constraint_validate_later",
+        "grants_deferred",
+        "cleanup_safe",
+        "cleanup_semantic",
+        "sequence_restart",
+        *MANUAL_REVIEW_DIRS,
+    }
     if not getattr(args, "allow_table_create", False):
         # Safety first: table create scripts are risky in migration workflows
         # because they can create empty target tables if OMS data load is skipped.
@@ -5556,6 +5742,13 @@ def main() -> None:
         log.warning("安全模式: 默认跳过 fixup_scripts/grants_deferred/（需对象补齐后再执行）。")
     if not any(dir_filter_overlaps("sequence_restart", item) for item in only_dirs):
         log.warning("安全模式: 默认跳过 fixup_scripts/sequence_restart/（值同步 SQL 需确认 LAST_NUMBER 与执行时机后再执行）。")
+    if not any(
+        any(dir_filter_overlaps(dir_name, item) for item in only_dirs)
+        for dir_name in MANUAL_REVIEW_DIRS
+    ):
+        log.warning(
+            "安全模式: 默认跳过 fixup_scripts/materialized_view|job|schedule/（manual-only family 需核对定义与人工事项后再显式执行）。"
+        )
     if not any(dir_filter_overlaps("cleanup_safe", item) for item in only_dirs):
         log.warning("安全模式: 默认跳过 fixup_scripts/cleanup_safe/（显式审核后再执行 destructive 清理 SQL）。")
     if not any(dir_filter_overlaps("cleanup_semantic", item) for item in only_dirs):
@@ -6428,9 +6621,11 @@ def run_iterative_fixup(
     cumulative_success = 0
     cumulative_failed = 0
     active_failed_paths: Set[Path] = set()
+    non_retryable_failed_paths: Set[Path] = set()
     recompile_owners: Set[str] = set()
     
     all_round_results = []
+    last_failure_results: List[ScriptResult] = []
     exec_stats = new_exec_mode_stats()
     
     while round_num < max_rounds:
@@ -6506,9 +6701,16 @@ def run_iterative_fixup(
             
             relative_path = sql_path.relative_to(repo_root)
             label = format_progress_label(idx, total_scripts, width)
+            normalized_path = normalize_failed_path(relative_path, repo_root)
+            contract = get_fixup_execution_contract(relative_path)
 
             if sql_path in pre_executed:
                 log.info("%s %s -> SKIP (已由依赖解析执行)", label, relative_path)
+                continue
+            if normalized_path in non_retryable_failed_paths:
+                msg = build_non_retryable_iterative_message(relative_path)
+                log.warning("%s %s -> SKIP (%s)", label, relative_path, msg)
+                round_results.append(ScriptResult(relative_path, "SKIPPED", msg, layer))
                 continue
 
             if is_grant_dir(sql_path.parent.name):
@@ -6577,6 +6779,16 @@ def run_iterative_fixup(
                             round_results.append(retry_result)
                             continue
                 round_results.append(result)
+                if result.status in ("FAILED", "ERROR") and not bool(contract.get("iterative_retry", True)):
+                    non_retryable_failed_paths.add(normalized_path)
+                    log.warning(
+                        "%s %s -> 保留失败；family=%s, support_tier=%s, retry_policy=%s。",
+                        label,
+                        relative_path,
+                        contract.get("family") or "-",
+                        contract.get("support_tier") or "-",
+                        contract.get("retry_policy") or "-",
+                    )
                 continue
 
             obj_type = DIR_OBJECT_TYPE_MAP.get(sql_path.parent.name.lower())
@@ -6619,6 +6831,16 @@ def run_iterative_fixup(
                             failure.index,
                             failure.statement,
                             failure.error
+                        )
+                    if not bool(contract.get("iterative_retry", True)):
+                        non_retryable_failed_paths.add(normalized_path)
+                        log.warning(
+                            "%s %s -> 保留失败；family=%s, support_tier=%s, retry_policy=%s。",
+                            label,
+                            relative_path,
+                            contract.get("family") or "-",
+                            contract.get("support_tier") or "-",
+                            contract.get("retry_policy") or "-",
                         )
                 continue
 
@@ -6721,6 +6943,16 @@ def run_iterative_fixup(
                             failure.statement,
                             failure.error
                         )
+                    if not bool(contract.get("iterative_retry", True)):
+                        non_retryable_failed_paths.add(normalized_path)
+                        log.warning(
+                            "%s %s -> 保留失败；family=%s, support_tier=%s, retry_policy=%s。",
+                            label,
+                            relative_path,
+                            contract.get("family") or "-",
+                            contract.get("support_tier") or "-",
+                            contract.get("retry_policy") or "-",
+                        )
                 continue
 
             round_results.append(result)
@@ -6736,6 +6968,16 @@ def run_iterative_fixup(
                         failure.statement,
                         failure.error
                     )
+                if not bool(contract.get("iterative_retry", True)):
+                    non_retryable_failed_paths.add(normalized_path)
+                    log.warning(
+                        "%s %s -> 保留失败；family=%s, support_tier=%s, retry_policy=%s。",
+                        label,
+                        relative_path,
+                        contract.get("family") or "-",
+                        contract.get("support_tier") or "-",
+                        contract.get("retry_policy") or "-",
+                    )
         
         # Round summary
         round_success = sum(1 for r in round_results if r.status == "SUCCESS")
@@ -6747,9 +6989,14 @@ def run_iterative_fixup(
             failed_path = normalize_failed_path(item.path, repo_root)
             if item.status in ("FAILED", "ERROR"):
                 active_failed_paths.add(failed_path)
+            elif failed_path in non_retryable_failed_paths:
+                active_failed_paths.add(failed_path)
             else:
                 active_failed_paths.discard(failed_path)
         cumulative_failed = len(active_failed_paths)
+        current_failure_results = [item for item in round_results if item.status in ("FAILED", "ERROR")]
+        if current_failure_results:
+            last_failure_results = current_failure_results
         
         log_subsection(f"第 {round_num} 轮结果")
         log.info("本轮成功: %d", round_success)
@@ -6771,7 +7018,7 @@ def run_iterative_fixup(
         if round_success < effective_min_progress:
             if round_success == 0:
                 log.warning("本轮无新成功脚本，停止迭代。")
-                failures_by_type = analyze_failure_patterns(round_results)
+                failures_by_type = analyze_failure_patterns(current_failure_results or last_failure_results)
                 if failures_by_type:
                     log_failure_analysis(failures_by_type)
             else:
@@ -6835,7 +7082,10 @@ def run_iterative_fixup(
     # Final failure analysis
     if round_num > 0 and all_round_results:
         final_results = all_round_results[-1]['results']
-        failures_by_type = analyze_failure_patterns(final_results)
+        failure_analysis_source = [item for item in final_results if item.status in ("FAILED", "ERROR")]
+        if not failure_analysis_source:
+            failure_analysis_source = last_failure_results
+        failures_by_type = analyze_failure_patterns(failure_analysis_source)
         if failures_by_type:
             log_failure_analysis(failures_by_type)
     

--- a/schema_diff_reconciler.py
+++ b/schema_diff_reconciler.py
@@ -16,7 +16,7 @@
 
 """
 
-数据库对象对比工具 (V0.9.9.3 - Dump-Once, Compare-Locally + 依赖 + ALTER 修补 + 注释校验)
+数据库对象对比工具 (V0.9.9.4 - Dump-Once, Compare-Locally + 依赖 + ALTER 修补 + 注释校验)
 ---------------------------------------------------------------------------
 功能概要：
 1. 对比 Oracle (源) 与 OceanBase (目标) 的：
@@ -33,7 +33,7 @@
    - INDEX / CONSTRAINT：校验存在性与列组合（含唯一性/约束类型）。
    - SEQUENCE / TRIGGER：校验存在性；依赖：映射后生成期望依赖并对比目标端。
 
-3. 性能架构 (V0.9.9.3 核心)：
+3. 性能架构 (V0.9.9.4 核心)：
    - OceanBase 侧采用“一次转储，本地对比”：
        使用少量 obclient 调用，分别 dump：
          DBA_OBJECTS
@@ -95,7 +95,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Callable, Dict, FrozenSet, Iterable, Iterator, List, NamedTuple, NoReturn, Optional, Pattern, Sequence, Set, Tuple, Union
 
-__version__ = "0.9.9.3"
+__version__ = "0.9.9.4"
 
 __author__ = "Minor Li"
 REPO_URL = "https://github.com/Minorli/ob_comparator"
@@ -1008,7 +1008,7 @@ class ContextCompareResults(NamedTuple):
     reference_rows: List[ContextReferenceRow]
     runnable_fixups: List[ContextFixupRow]
     manual_fixups: List[ContextFixupRow]
-    summary: Dict[str, int]
+    summary: Dict[str, object]
 
 
 class ViewCompatResult(NamedTuple):
@@ -1291,6 +1291,8 @@ class ObMetadata(NamedTuple):
     enabled_notnull_check_columns: Dict[Tuple[str, str], Dict[str, Dict[str, str]]] = MappingProxyType({})  # (OWNER, TABLE_NAME) -> {COLUMN_NAME: enabled single-column IS NOT NULL check meta}
     enabled_notnull_check_groups: Dict[Tuple[str, str], Dict[str, Tuple["NotnullCheckEntry", ...]]] = MappingProxyType({})  # (OWNER, TABLE_NAME) -> {COLUMN_NAME: (enabled single-column IS NOT NULL checks...)}
     contexts: Dict[str, ContextMetadata] = MappingProxyType({})
+    context_inventory_error: str = ""
+    context_inventory_health: str = "HEALTHY"
 
 
 class OracleMetadata(NamedTuple):
@@ -1331,6 +1333,8 @@ class OracleMetadata(NamedTuple):
     identity_options: Dict[Tuple[str, str], Dict[str, Dict[str, str]]] = MappingProxyType({})  # (OWNER, TABLE_NAME) -> {COLUMN_NAME: {OPTION: VALUE}}
     nested_table_storage_tables: Dict[Tuple[str, str], "NestedTableStorageInfo"] = MappingProxyType({})  # (OWNER, STORAGE_TABLE_NAME) -> parent table/column
     contexts: Dict[str, ContextMetadata] = MappingProxyType({})
+    context_inventory_error: str = ""
+    context_inventory_health: str = "HEALTHY"
 
 
 class NestedTableStorageInfo(NamedTuple):
@@ -1775,7 +1779,11 @@ CONTEXT_REFERENCE_ELIGIBLE_TYPES: FrozenSet[str] = frozenset({
 })
 CONTEXT_REFERENCE_BUILTIN_NAMESPACES: FrozenSet[str] = frozenset({
     "USERENV",
+    "SYS_SESSION_ROLES",
 })
+CONTEXT_INVENTORY_HEALTH_HEALTHY = "HEALTHY"
+CONTEXT_INVENTORY_HEALTH_DEGRADED = "DEGRADED"
+CONTEXT_INVENTORY_HEALTH_FAILED = "FAILED"
 CONTEXT_FIXUP_MODE_VALUES: Set[str] = {"manual", "safe_auto"}
 CONTEXT_FIXUP_MODE_ALIASES: Dict[str, str] = {
     "auto": "safe_auto",
@@ -1792,10 +1800,16 @@ CONTEXT_MODE_INITIALIZED_GLOBALLY = "INITIALIZED GLOBALLY"
 CONTEXT_MODE_ALIASES: Dict[str, str] = {
     CONTEXT_MODE_LOCAL: CONTEXT_MODE_LOCAL,
     "LOCAL": CONTEXT_MODE_LOCAL,
+    "ACCESSED LOCAL": CONTEXT_MODE_LOCAL,
     CONTEXT_MODE_GLOBAL: CONTEXT_MODE_GLOBAL,
     "GLOBAL": CONTEXT_MODE_GLOBAL,
+    "ACCESSED GLOBAL": CONTEXT_MODE_GLOBAL,
     CONTEXT_MODE_INITIALIZED_EXTERNALLY: CONTEXT_MODE_INITIALIZED_EXTERNALLY,
+    "EXTERNAL": CONTEXT_MODE_INITIALIZED_EXTERNALLY,
+    "INITIALIZED EXTERNAL": CONTEXT_MODE_INITIALIZED_EXTERNALLY,
     CONTEXT_MODE_INITIALIZED_GLOBALLY: CONTEXT_MODE_INITIALIZED_GLOBALLY,
+    "GLOBAL INIT": CONTEXT_MODE_INITIALIZED_GLOBALLY,
+    "INITIALIZED GLOBAL": CONTEXT_MODE_INITIALIZED_GLOBALLY,
 }
 CONTEXT_CERTIFIED_MODES: FrozenSet[str] = frozenset({
     CONTEXT_MODE_LOCAL,
@@ -1843,8 +1857,12 @@ MVIEW_CHECK_FIXUP_MODE_ALIASES: Dict[str, str] = {
     "disable": "off",
     "disabled": "off",
 }
-GTT_TABLE_HANDLING_MODE_VALUES: Set[str] = {"rewrite_to_normal", "preserve_original", "blocked"}
+GTT_TABLE_HANDLING_MODE_VALUES: Set[str] = {"auto", "rewrite_to_normal", "preserve_original", "blocked"}
 GTT_TABLE_HANDLING_MODE_ALIASES: Dict[str, str] = {
+    "native": "preserve_original",
+    "on": "auto",
+    "true": "auto",
+    "1": "auto",
     "rewrite": "rewrite_to_normal",
     "rewrite_normal": "rewrite_to_normal",
     "rewrite_to_heap": "rewrite_to_normal",
@@ -1917,6 +1935,12 @@ EXCLUDED_STATUS_FILTERED_BY_MISSING_CREATED = "FILTERED_BY_MISSING_CREATED"
 TEMP_TABLE_BLACKLIST_TYPES: Set[str] = {"TEMP_TABLE", "TEMPORARY_TABLE"}
 TRIGGER_TEMP_TABLE_UNSUPPORTED_REASON_CODE = "TRIGGER_ON_TEMP_TABLE_UNSUPPORTED"
 TRIGGER_TEMP_TABLE_UNSUPPORTED_REASON = "OB 不支持在临时表上创建 DML 触发器（实测 ORA-00600/-4007）"
+OB_SOURCE_TEMP_TABLE_MANUAL_ONLY_REASON_CODE = "OB_SOURCE_TEMP_TABLE_MANUAL_ONLY"
+OB_SOURCE_TEMP_TABLE_MANUAL_ONLY_REASON = "OceanBase source 临时表当前未进入 certified TABLE fixup contract。"
+OB_SOURCE_TEMP_TABLE_MANUAL_ONLY_ACTION = "人工确认 temporary table 语义并手工处理"
+OB_SOURCE_TABLE_DDL_LOW_FIDELITY_REASON_CODE = "OB_SOURCE_TABLE_DDL_LOW_FIDELITY"
+OB_SOURCE_TABLE_DDL_LOW_FIDELITY_REASON = "OceanBase source TABLE 当前仅命中低保真 provider，禁止生成 runnable CREATE TABLE。"
+OB_SOURCE_TABLE_DDL_LOW_FIDELITY_ACTION = "改用高保真 DDL provider 或人工审核后手工处理"
 NESTED_TABLE_STORAGE_REASON_CODE = "NESTED_TABLE_STORAGE"
 NESTED_TABLE_STORAGE_REASON = "Oracle nested table storage table，不能作为普通 TABLE 单独迁移"
 NESTED_TABLE_STORAGE_ACTION = "按父表 nested column 人工评估/改造"
@@ -1941,6 +1965,9 @@ SUPPORT_STATE_SUPPORTED = "SUPPORTED"
 SUPPORT_STATE_UNSUPPORTED = "UNSUPPORTED"
 SUPPORT_STATE_BLOCKED = "BLOCKED"
 SUPPORT_STATE_RISKY = "RISKY"
+OB_SOURCE_DDL_FIDELITY_CERTIFIED = "certified"
+OB_SOURCE_DDL_FIDELITY_PREVIEW = "preview"
+OB_SOURCE_DDL_FIDELITY_MANUAL_ONLY = "manual-only"
 
 
 def support_state_to_report_type(support_state: str) -> str:
@@ -2279,6 +2306,17 @@ def normalize_identifier_name(name: Optional[str]) -> str:
     return text.upper()
 
 
+def normalize_semantic_identifier_name(name: Optional[str]) -> str:
+    if not name:
+        return ""
+    text = str(name).strip()
+    if len(text) >= 2 and text.startswith('"') and text.endswith('"'):
+        return text[1:-1].replace('""', '"')
+    if any(ch.islower() for ch in text):
+        return text
+    return text.upper()
+
+
 def is_case_sensitive_identifier(raw_name: Optional[str]) -> bool:
     if raw_name is None:
         return False
@@ -2518,6 +2556,17 @@ def normalize_ob_metadata_flag(value: Optional[str]) -> Optional[bool]:
     if text in ("NO", "N", "FALSE", "0"):
         return False
     return None
+
+
+def normalize_obclient_nullable_text(value: Optional[object], *, upper: bool = False) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.upper() in {"NULL", "<NULL>", "NONE", "N/A"}:
+        return None
+    return text.upper() if upper else text
 
 
 def metadata_value_missing(value: Optional[object]) -> bool:
@@ -2954,19 +3003,20 @@ def _extract_single_column_is_notnull_identifier(search_condition: Optional[str]
     cond = normalize_sql_expression(search_condition)
     if not cond:
         return ""
-    cond_u = uppercase_outside_single_quotes(cond).strip()
-    while cond_u.startswith("(") and cond_u.endswith(")"):
-        stripped = strip_wrapping_parentheses(cond_u)
-        if stripped == cond_u:
+    cond_text = cond.strip()
+    while cond_text.startswith("(") and cond_text.endswith(")"):
+        stripped = strip_wrapping_parentheses(cond_text)
+        if stripped == cond_text:
             break
-        cond_u = stripped.strip()
-    match = re.match(r'^(?P<ident>"(?:[^"]|"")+"|[A-Z0-9_#$]+)\s+IS\s+NOT\s+NULL$', cond_u)
+        cond_text = stripped.strip()
+    match = re.match(
+        r'^(?P<ident>"(?:[^"]|"")+"|[A-Za-z0-9_#$]+)\s+IS\s+NOT\s+NULL$',
+        cond_text,
+        flags=re.IGNORECASE,
+    )
     if not match:
         return ""
-    ident = match.group("ident")
-    if ident.startswith('"') and ident.endswith('"'):
-        ident = ident[1:-1].replace('""', '"')
-    return normalize_identifier_name(ident)
+    return normalize_semantic_identifier_name(match.group("ident"))
 
 
 def is_notnull_check_condition(search_condition: Optional[str]) -> bool:
@@ -3278,10 +3328,10 @@ def build_system_notnull_novalidate_column_map(constraints: Optional[Dict[str, D
         col = _extract_notnull_column(search_condition)
         if not col:
             continue
-        col_u = col.upper()
-        if col_u in result:
+        col_key = normalize_semantic_identifier_name(col)
+        if col_key in result:
             continue
-        result[col_u] = {
+        result[col_key] = {
             "constraint_name": extract_constraint_name(cons_name).upper(),
             "search_condition": normalize_sql_expression(search_condition),
             "status": normalize_constraint_enabled_status(cons.get("status")),
@@ -3306,8 +3356,8 @@ def build_enabled_notnull_check_group_map(
         col = _extract_notnull_column(search_condition)
         if not col:
             continue
-        col_u = col.upper()
-        result.setdefault(col_u, []).append(NotnullCheckEntry(
+        col_key = normalize_semantic_identifier_name(col)
+        result.setdefault(col_key, []).append(NotnullCheckEntry(
             constraint_name=extract_constraint_name(cons_name).upper(),
             search_condition=normalize_sql_expression(search_condition),
             status=normalize_constraint_enabled_status(cons.get("status")),
@@ -3316,8 +3366,8 @@ def build_enabled_notnull_check_group_map(
             is_system_named=is_system_notnull_check(extract_constraint_name(cons_name), search_condition),
         ))
     return {
-        col_u: tuple(entries)
-        for col_u, entries in result.items()
+        col_key: tuple(entries)
+        for col_key, entries in result.items()
     }
 
 
@@ -4334,7 +4384,7 @@ def normalize_context_fixup_mode(raw_value: Optional[str]) -> str:
 
 
 def normalize_context_inventory_type(raw_value: Optional[object]) -> str:
-    text = re.sub(r"\s+", " ", str(raw_value or "").strip().upper())
+    text = re.sub(r"[_\s]+", " ", str(raw_value or "").strip().upper())
     return CONTEXT_MODE_ALIASES.get(text, text)
 
 
@@ -4349,9 +4399,9 @@ def format_context_binding(schema_name: Optional[str], package_name: Optional[st
 
 
 def build_ob_context_create_ddl(context_meta: ContextMetadata) -> Optional[str]:
-    namespace_u = normalize_identifier_name(context_meta.namespace)
-    schema_u = normalize_identifier_name(context_meta.schema)
-    package_u = normalize_identifier_name(context_meta.package)
+    namespace_u = normalize_semantic_identifier_name(context_meta.namespace)
+    schema_u = normalize_semantic_identifier_name(context_meta.schema)
+    package_u = normalize_semantic_identifier_name(context_meta.package)
     mode_u = normalize_context_inventory_type(context_meta.type)
     if not namespace_u or not package_u:
         return None
@@ -4362,6 +4412,215 @@ def build_ob_context_create_ddl(context_meta: ContextMetadata) -> Optional[str]:
     if mode_u == CONTEXT_MODE_GLOBAL:
         return base + " ACCESSED GLOBALLY;"
     return None
+
+
+SOURCE_SUPPORT_TIER_CERTIFIED = "certified"
+SOURCE_SUPPORT_TIER_PREVIEW = "preview"
+SOURCE_SUPPORT_TIER_MANUAL_ONLY = "manual-only"
+SOURCE_SUPPORT_TIER_UNSUPPORTED = "unsupported"
+
+OB_SOURCE_FAMILY_CONTRACTS: "OrderedDict[str, Dict[str, object]]" = OrderedDict([
+    ("TABLE", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "table/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+        "provider_fidelity": OrderedDict([
+            ("OB_DBMS_METADATA", OB_SOURCE_DDL_FIDELITY_CERTIFIED),
+            ("OB_TABLE_META", OB_SOURCE_DDL_FIDELITY_MANUAL_ONLY),
+        ]),
+    }),
+    ("VIEW", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "view/|view_refresh/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("PROCEDURE", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "procedure/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("FUNCTION", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "function/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("PACKAGE", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "package/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("PACKAGE BODY", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "package_body/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("TYPE", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "type/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("TYPE BODY", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "type_body/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("CONTEXT", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "context/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("SYNONYM", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "synonym/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("SEQUENCE", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "sequence/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("INDEX", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "index/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("CONSTRAINT", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "constraint/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("TRIGGER", {
+        "support_tier": SOURCE_SUPPORT_TIER_CERTIFIED,
+        "certified_entry": "trigger/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_CERTIFIED,
+    }),
+    ("NON_TABLE_TRIGGER", {
+        "support_tier": SOURCE_SUPPORT_TIER_MANUAL_ONLY,
+        "certified_entry": "manual_actions_required + triggers_non_table_detail",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_MANUAL_ONLY,
+        "manual_reason": "非表触发器不进入 certified fixup，需人工改造或确认保留空缺。",
+    }),
+    ("MATERIALIZED VIEW", {
+        "support_tier": SOURCE_SUPPORT_TIER_MANUAL_ONLY,
+        "certified_entry": "materialized_view/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_MANUAL_ONLY,
+        "manual_reason": "当前仅输出 manual-only contract，不纳入 certified auto-fix。",
+    }),
+    ("JOB", {
+        "support_tier": SOURCE_SUPPORT_TIER_MANUAL_ONLY,
+        "certified_entry": "job/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_MANUAL_ONLY,
+        "manual_reason": "JOB 当前属于 manual-only / semi_auto 草案范畴。",
+    }),
+    ("SCHEDULE", {
+        "support_tier": SOURCE_SUPPORT_TIER_MANUAL_ONLY,
+        "certified_entry": "schedule/",
+        "default_provider_fidelity": OB_SOURCE_DDL_FIDELITY_MANUAL_ONLY,
+        "manual_reason": "SCHEDULE 当前属于 manual-only / semi_auto 草案范畴。",
+    }),
+])
+
+
+def build_ob_source_family_tier_map(
+    support_tiers: Optional[Dict[str, object]] = None,
+) -> "OrderedDict[str, str]":
+    families = (support_tiers or {}).get("families") or {}
+    if families:
+        return OrderedDict(
+            (str(name), str(tier))
+            for name, tier in families.items()
+        )
+    return OrderedDict(
+        (name, str(contract.get("support_tier") or SOURCE_SUPPORT_TIER_UNSUPPORTED))
+        for name, contract in OB_SOURCE_FAMILY_CONTRACTS.items()
+    )
+
+
+def build_ob_source_family_tier_summary(
+    support_tiers: Optional[Dict[str, object]] = None,
+    tiers: Optional[Set[str]] = None,
+) -> str:
+    normalized_tiers = {str(item).strip().lower() for item in (tiers or set()) if str(item).strip()}
+    pieces: List[str] = []
+    for name, tier in build_ob_source_family_tier_map(support_tiers).items():
+        tier_u = str(tier or "").strip().lower()
+        if normalized_tiers and tier_u not in normalized_tiers:
+            continue
+        pieces.append(f"{name}={tier}")
+    return ", ".join(pieces)
+
+
+def get_ob_source_family_contract(obj_type: Optional[str]) -> Dict[str, object]:
+    obj_type_u = (obj_type or "").upper()
+    contract = OB_SOURCE_FAMILY_CONTRACTS.get(obj_type_u)
+    if contract is None:
+        return {
+            "support_tier": SOURCE_SUPPORT_TIER_UNSUPPORTED,
+            "certified_entry": "report-only",
+            "default_provider_fidelity": SOURCE_SUPPORT_TIER_UNSUPPORTED,
+            "provider_fidelity": OrderedDict(),
+        }
+    return dict(contract)
+
+
+def get_ob_source_family_provider_fidelity_map(
+    obj_type: Optional[str],
+) -> "OrderedDict[str, str]":
+    contract = get_ob_source_family_contract(obj_type)
+    provider_map = OrderedDict(
+        (str(name), str(fidelity))
+        for name, fidelity in ((contract.get("provider_fidelity") or {}).items())
+    )
+    if provider_map:
+        return provider_map
+    default_fidelity = str(
+        contract.get("default_provider_fidelity")
+        or contract.get("support_tier")
+        or OB_SOURCE_DDL_FIDELITY_CERTIFIED
+    )
+    return OrderedDict([("DEFAULT", default_fidelity)])
+
+
+def build_ob_source_contract_summary_lines(
+    support_tiers: Optional[Dict[str, object]] = None,
+) -> List[str]:
+    lines: List[str] = []
+    version_pair = str((support_tiers or {}).get("version_pair") or "").strip()
+    if version_pair:
+        lines.append(f"OB source version pair: {version_pair}")
+    deferred_summary = build_ob_source_family_tier_summary(
+        support_tiers,
+        tiers={SOURCE_SUPPORT_TIER_PREVIEW, SOURCE_SUPPORT_TIER_MANUAL_ONLY},
+    )
+    if deferred_summary:
+        lines.append(f"OB source deferred/manual families: {deferred_summary}")
+    table_provider_summary = ", ".join(
+        f"{provider}={fidelity}"
+        for provider, fidelity in get_ob_source_family_provider_fidelity_map("TABLE").items()
+    )
+    if table_provider_summary:
+        lines.append(f"OB source provider fidelity: TABLE({table_provider_summary})")
+    return lines
+
+
+def build_ob_source_support_tier_matrix(
+    source_version: Optional[str] = None,
+    target_version: Optional[str] = None,
+) -> Dict[str, object]:
+    source_version_text = str(source_version or "").strip() or "unknown"
+    target_version_text = str(target_version or "").strip() or "unknown"
+    return {
+        "version_pair": f"{source_version_text} -> {target_version_text}",
+        "features": OrderedDict([
+            ("grant_generation", SOURCE_SUPPORT_TIER_CERTIFIED),
+            ("source_object_created_before", SOURCE_SUPPORT_TIER_CERTIFIED),
+            ("scope_closure", SOURCE_SUPPORT_TIER_CERTIFIED),
+            ("source_usability", SOURCE_SUPPORT_TIER_CERTIFIED),
+            ("table_data_presence", SOURCE_SUPPORT_TIER_CERTIFIED),
+            ("oracle_blacklist", SOURCE_SUPPORT_TIER_UNSUPPORTED),
+        ]),
+        "families": build_ob_source_family_tier_map(),
+    }
 
 
 def build_source_capability_registry(source_db_mode: str) -> Dict[str, bool]:
@@ -4384,12 +4643,12 @@ def build_source_capability_registry(source_db_mode: str) -> Dict[str, bool]:
     return {
         "requires_oracle_client": False,
         "supports_fixup_generation": True,
-        "supports_grant_generation": False,
+        "supports_grant_generation": True,
         "supports_blacklist_table": False,
-        "supports_source_object_created_before": False,
-        "supports_scope_closure": False,
-        "supports_source_usability": False,
-        "supports_table_presence": False,
+        "supports_source_object_created_before": True,
+        "supports_scope_closure": True,
+        "supports_source_usability": True,
+        "supports_table_presence": True,
         "supports_missing_classification": True,
         "supports_source_synonym_metadata": True,
         "supports_source_parent_map": True,
@@ -4405,6 +4664,83 @@ def summarize_ob_source_fixup_families() -> Tuple[List[str], List[str]]:
 
 def is_ob_source_fixup_supported_type(obj_type: Optional[str]) -> bool:
     return (obj_type or "").upper() in OB_SOURCE_FIXUP_SUPPORTED_TYPES
+
+
+def get_ob_source_ddl_provider_fidelity(
+    obj_type: Optional[str],
+    source_label: Optional[str],
+) -> str:
+    label_u = (source_label or "").upper()
+    provider_map = get_ob_source_family_provider_fidelity_map(obj_type)
+    if label_u and label_u in provider_map:
+        return provider_map[label_u]
+    if "DEFAULT" in provider_map:
+        return provider_map["DEFAULT"]
+    if provider_map:
+        return next(iter(provider_map.values()))
+    return OB_SOURCE_DDL_FIDELITY_CERTIFIED
+
+
+def is_ob_source_temp_table_key(
+    oracle_meta: Optional[OracleMetadata],
+    owner: Optional[str],
+    table_name: Optional[str],
+) -> bool:
+    owner_u = (owner or "").upper()
+    table_u = (table_name or "").upper()
+    if not owner_u or not table_u:
+        return False
+    temporary_tables = {
+        ((src_owner or "").upper(), (src_table or "").upper())
+        for src_owner, src_table in (getattr(oracle_meta, "temporary_tables", set()) or set())
+    }
+    return (owner_u, table_u) in temporary_tables
+
+
+def build_ob_source_temp_table_support_row(
+    obj_type_u: str,
+    src_full_u: str,
+    tgt_full_u: str,
+    *,
+    dependency: str = "-",
+    detail: str = "-",
+) -> ObjectSupportReportRow:
+    return ObjectSupportReportRow(
+        obj_type=obj_type_u,
+        src_full=src_full_u,
+        tgt_full=tgt_full_u,
+        support_state=SUPPORT_STATE_RISKY,
+        reason_code=OB_SOURCE_TEMP_TABLE_MANUAL_ONLY_REASON_CODE,
+        reason=OB_SOURCE_TEMP_TABLE_MANUAL_ONLY_REASON,
+        dependency=dependency or "-",
+        action=OB_SOURCE_TEMP_TABLE_MANUAL_ONLY_ACTION,
+        detail=detail or "-",
+        root_cause=f"{src_full_u}({OB_SOURCE_TEMP_TABLE_MANUAL_ONLY_REASON_CODE})",
+    )
+
+
+def build_ob_source_low_fidelity_table_support_row(
+    src_schema: str,
+    src_table: str,
+    tgt_schema: str,
+    tgt_table: str,
+    source_label: Optional[str],
+) -> ObjectSupportReportRow:
+    src_full_u = f"{(src_schema or '').upper()}.{(src_table or '').upper()}".strip(".")
+    tgt_full_u = f"{(tgt_schema or '').upper()}.{(tgt_table or '').upper()}".strip(".")
+    fidelity = get_ob_source_ddl_provider_fidelity("TABLE", source_label)
+    return ObjectSupportReportRow(
+        obj_type="TABLE",
+        src_full=src_full_u,
+        tgt_full=tgt_full_u,
+        support_state=SUPPORT_STATE_RISKY,
+        reason_code=OB_SOURCE_TABLE_DDL_LOW_FIDELITY_REASON_CODE,
+        reason=OB_SOURCE_TABLE_DDL_LOW_FIDELITY_REASON,
+        dependency="-",
+        action=OB_SOURCE_TABLE_DDL_LOW_FIDELITY_ACTION,
+        detail=f"ddl_source={((source_label or '-').upper())}; fidelity={fidelity}",
+        root_cause=f"{src_full_u}({OB_SOURCE_TABLE_DDL_LOW_FIDELITY_REASON_CODE})",
+    )
 
 
 def is_same_ob_endpoint(source_ob_cfg: Optional[ObConfig], target_ob_cfg: Optional[ObConfig]) -> bool:
@@ -4442,6 +4778,28 @@ def build_source_mode_diagnostics(
             "OB source/target versions: source={src}, target={tgt}".format(
                 src=source_version or "unknown",
                 tgt=target_version or "unknown",
+            )
+        )
+
+    support_tiers = settings.get("source_support_tiers") or build_ob_source_support_tier_matrix(
+        source_version,
+        target_version,
+    )
+    version_pair = str((support_tiers or {}).get("version_pair") or "").strip()
+    if version_pair:
+        diagnostics.append(f"OB source version-pair certification: {version_pair}")
+    feature_tiers = (support_tiers or {}).get("features") or {}
+    if feature_tiers:
+        diagnostics.append(
+            "OB source feature tiers: " + ", ".join(
+                f"{name}={tier}" for name, tier in feature_tiers.items()
+            )
+        )
+    family_tiers = (support_tiers or {}).get("families") or {}
+    if family_tiers:
+        diagnostics.append(
+            "OB source family tiers: " + ", ".join(
+                f"{name}={tier}" for name, tier in family_tiers.items()
             )
         )
 
@@ -4504,6 +4862,18 @@ def build_source_mode_diagnostics(
     return diagnostics
 
 
+def dedupe_preserve_order(items: Sequence[str]) -> List[str]:
+    seen: Set[str] = set()
+    result: List[str] = []
+    for item in (items or ()):
+        text = str(item or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
+
+
 def normalize_interval_partition_fixup_mode(raw_value: Optional[str]) -> str:
     value = (raw_value or "").strip().lower()
     if not value:
@@ -4544,6 +4914,27 @@ def normalize_gtt_table_handling_mode(raw_value: Optional[str]) -> str:
         )
         return "rewrite_to_normal"
     return value
+
+
+def resolve_effective_gtt_table_handling_mode(settings: Optional[Dict]) -> Tuple[str, List[str]]:
+    settings = settings or {}
+    configured_mode = normalize_gtt_table_handling_mode(settings.get("gtt_table_handling_mode", "rewrite_to_normal"))
+    version_known = bool(settings.get("ob_version_known"))
+    is_ob_442_plus = bool(settings.get("ob_is_442_plus"))
+    diagnostics: List[str] = []
+    if configured_mode == "auto":
+        if version_known and is_ob_442_plus:
+            diagnostics.append("gtt_table_handling_mode=auto：目标 OB 版本支持原生 GTT，已切换为 preserve_original。")
+            return "preserve_original", diagnostics
+        if version_known:
+            diagnostics.append("gtt_table_handling_mode=auto：目标 OB 版本不满足原生 GTT 条件，已回退为 rewrite_to_normal。")
+        else:
+            diagnostics.append("gtt_table_handling_mode=auto：目标 OB 版本未知，已保守回退为 rewrite_to_normal。")
+        return "rewrite_to_normal", diagnostics
+    if configured_mode == "preserve_original" and version_known and not is_ob_442_plus:
+        diagnostics.append("gtt_table_handling_mode=preserve_original：目标 OB 版本不满足原生 GTT 条件，已降级为 blocked。")
+        return "blocked", diagnostics
+    return configured_mode, diagnostics
 
 
 def parse_type_list(
@@ -4996,12 +5387,20 @@ def collect_fixup_config_diagnostics(
     source_scope_mode = normalize_source_object_scope_mode(
         settings.get("source_object_scope_mode", "full_source")
     )
-    if source_scope_mode == "remap_root_closure":
+    if is_scoped_source_mode(source_scope_mode):
         remap_file = (settings.get("remap_file") or "").strip()
         if not remap_file:
-            diagnostics.append("source_object_scope_mode=remap_root_closure 但 remap_file 为空，运行时会 fail-fast。")
+            diagnostics.append(
+                "source_object_scope_mode={mode} 但 remap_file 为空，运行时会 fail-fast。".format(
+                    mode=source_scope_mode
+                )
+            )
         if trigger_list_path and "TRIGGER" not in enabled_extra_types:
-            diagnostics.append("source_object_scope_mode=remap_root_closure 且配置了 trigger_list，但 check_extra_types 未启用 TRIGGER，运行时会 fail-fast。")
+            diagnostics.append(
+                "source_object_scope_mode={mode} 且配置了 trigger_list，但 check_extra_types 未启用 TRIGGER，运行时会 fail-fast。".format(
+                    mode=source_scope_mode
+                )
+            )
 
     name_collision_mode = normalize_name_collision_mode(settings.get("name_collision_mode", "fixup"))
     rename_existing = parse_bool_flag(settings.get("name_collision_rename_existing", "true"), True)
@@ -5226,10 +5625,14 @@ REPORT_DIR_LAYOUT_ALIASES = {
     "single": "flat",
 }
 
-SOURCE_OBJECT_SCOPE_MODE_VALUES = {"full_source", "remap_root_closure"}
+SOURCE_OBJECT_SCOPE_MODE_VALUES = {"full_source", "explicit_roots", "remap_root_closure"}
 SOURCE_OBJECT_SCOPE_MODE_ALIASES = {
     "full": "full_source",
     "fullsource": "full_source",
+    "roots": "explicit_roots",
+    "explicit": "explicit_roots",
+    "explicit-roots": "explicit_roots",
+    "explicitroots": "explicit_roots",
     "closure": "remap_root_closure",
     "remap_closure": "remap_root_closure",
     "remap-root-closure": "remap_root_closure",
@@ -5257,6 +5660,10 @@ def normalize_source_object_scope_mode(raw_value: Optional[str]) -> str:
         log.warning("source_object_scope_mode=%s 不在支持范围内，将回退为 full_source。", raw_value)
         return "full_source"
     return value
+
+
+def is_scoped_source_mode(raw_value: Optional[str]) -> bool:
+    return normalize_source_object_scope_mode(raw_value) in {"explicit_roots", "remap_root_closure"}
 
 
 REMAP_SCOPE_TEXT_FALLBACK_MODE_VALUES = {"off", "safe"}
@@ -5350,9 +5757,7 @@ SCOPED_TEXT_REFERENCE_TARGET_TYPES: Set[str] = {
     "PROCEDURE",
     "FUNCTION",
     "PACKAGE",
-    "PACKAGE BODY",
     "TYPE",
-    "TYPE BODY",
     "SYNONYM",
     "SEQUENCE",
 }
@@ -5369,7 +5774,7 @@ def _build_schema_qualified_reference_patterns(full_name: str) -> Tuple[re.Patte
         re.compile(rf'(?<![A-Z0-9_$#"])' + owner_re + r'\s*\.\s*' + name_re + r'(?![A-Z0-9_$#"])'),
         re.compile(rf'"{owner_re}"\s*\.\s*"{name_re}"'),
         re.compile(rf'"{owner_re}"\s*\.\s*' + name_re + r'(?![A-Z0-9_$#"])'),
-        re.compile(rf'(?<![A-Z0-9_$#"])' + owner_re + r'\s*\.\s*"{name_re}"'),
+        re.compile(rf'(?<![A-Z0-9_$#"]){owner_re}\s*\.\s*"{name_re}"'),
     )
 
 
@@ -5391,7 +5796,7 @@ def _build_scoped_reference_patterns(full_name: str, object_types: Set[str]) -> 
             rf'(?<![A-Z0-9_$#"])' + owner_re + r'\s*\.\s*' + name_re,
             rf'"{owner_re}"\s*\.\s*"{name_re}"',
             rf'"{owner_re}"\s*\.\s*' + name_re,
-            rf'(?<![A-Z0-9_$#"])' + owner_re + r'\s*\.\s*"{name_re}"',
+            rf'(?<![A-Z0-9_$#"]){owner_re}\s*\.\s*"{name_re}"',
         ]
         statement_prefix = r'(?:^|[;\n]|\bBEGIN\b|\bTHEN\b|\bELSE\b|\bLOOP\b)\s*'
         for prefix in package_prefix_variants:
@@ -5402,7 +5807,7 @@ def _build_scoped_reference_patterns(full_name: str, object_types: Set[str]) -> 
             re.compile(rf'(?<![A-Z0-9_$#"])' + owner_re + r'\s*\.\s*' + name_re + r'\s*(?=[(;])'),
             re.compile(rf'"{owner_re}"\s*\.\s*"{name_re}"\s*(?=[(;])'),
             re.compile(rf'"{owner_re}"\s*\.\s*' + name_re + r'\s*(?=[(;])'),
-            re.compile(rf'(?<![A-Z0-9_$#"])' + owner_re + r'\s*\.\s*"{name_re}"\s*(?=[(;])'),
+            re.compile(rf'(?<![A-Z0-9_$#"]){owner_re}\s*\.\s*"{name_re}"\s*(?=[(;])'),
         ])
     return tuple(patterns)
 
@@ -5640,7 +6045,7 @@ def _extract_dynamic_sql_literals_for_scan(sql: str) -> Tuple[List[str], List[st
         else:
             _append_ambiguity('EXECUTE_IMMEDIATE', expr, reason)
 
-    for match in re.finditer(r'\bDBMS_SQL\s*\.\s*PARSE\s*\(', masked):
+    for match in re.finditer(r'\b(?:(?:[A-Z0-9_$#]+|"[^"]+")\s*\.\s*)?DBMS_SQL\s*\.\s*PARSE\s*\(', masked):
         open_pos = masked.find("(", match.start())
         if open_pos == -1:
             continue
@@ -5664,6 +6069,93 @@ def _extract_dynamic_sql_literals_for_scan(sql: str) -> Tuple[List[str], List[st
             _append_ambiguity('DBMS_SQL.PARSE', candidate_expr, reason)
 
     return literals, ambiguities
+
+
+_SCHEDULER_CREATE_CALL_RE = re.compile(
+    r'\b(?:(?:[A-Z0-9_$#]+|"[^"]+")\s*\.\s*)?DBMS_SCHEDULER\s*\.\s*(CREATE_JOB|CREATE_SCHEDULE)\s*\(',
+    re.IGNORECASE,
+)
+
+
+def _normalize_scheduler_created_object_full_name(
+    object_name: str,
+    default_owner: str,
+) -> Optional[str]:
+    raw_value = str(object_name or "").strip()
+    if not raw_value:
+        return None
+    normalized_qualified = normalize_qualified_name(raw_value)
+    if normalized_qualified:
+        parsed = parse_full_object_name(normalized_qualified)
+        if parsed and parsed[0] and parsed[1]:
+            return f"{parsed[0].upper()}.{parsed[1].upper()}"
+    owner_u = normalize_identifier_name(default_owner)
+    name_u = normalize_identifier_name(raw_value)
+    if not owner_u or not name_u:
+        return None
+    return f"{owner_u}.{name_u}"
+
+
+def _extract_scheduler_created_object_refs(
+    sql: str,
+    default_owner: str,
+) -> Tuple[List[Tuple[str, str, str]], List[str]]:
+    if not sql:
+        return [], []
+    masked = mask_sql_for_scan(sql).upper()
+    refs: List[Tuple[str, str, str]] = []
+    ambiguities: List[str] = []
+    seen_refs: Set[Tuple[str, str]] = set()
+    seen_ambiguities: Set[str] = set()
+
+    def _append_ref(full_name: Optional[str], obj_type: str, source_tag: str) -> None:
+        full_u = (full_name or "").upper()
+        type_u = (obj_type or "").upper()
+        if not full_u or not type_u:
+            return
+        key = (full_u, type_u)
+        if key in seen_refs:
+            return
+        seen_refs.add(key)
+        refs.append((full_u, type_u, source_tag))
+
+    def _append_ambiguity(call_name: str, expr: str, reason: Optional[str]) -> None:
+        preview = " ".join((expr or "").strip().split())[:160] or "-"
+        detail = f"{call_name}:{(reason or 'UNRESOLVED')}:{preview}"
+        if detail in seen_ambiguities:
+            return
+        seen_ambiguities.add(detail)
+        ambiguities.append(detail)
+
+    for match in _SCHEDULER_CREATE_CALL_RE.finditer(masked):
+        call_name = (match.group(1) or "").upper()
+        open_pos = masked.find("(", match.start())
+        if open_pos == -1:
+            continue
+        args = _split_top_level_call_arguments(sql, open_pos, masked)
+        if not args:
+            continue
+        is_job = call_name == "CREATE_JOB"
+        obj_type = "JOB" if is_job else "SCHEDULE"
+        name_expr = _extract_named_or_positional_call_arg(
+            args,
+            position=0,
+            names=("job_name",) if is_job else ("schedule_name",),
+        )
+        if not name_expr:
+            _append_ambiguity(call_name, "", "NAME_ARG_MISSING")
+            continue
+        folded_name, reason = _fold_dynamic_sql_expression(name_expr)
+        if folded_name is None:
+            _append_ambiguity(call_name, name_expr, reason)
+            continue
+        full_name = _normalize_scheduler_created_object_full_name(folded_name, default_owner)
+        if not full_name:
+            _append_ambiguity(call_name, name_expr, "NAME_PARSE_FAILED")
+            continue
+        _append_ref(full_name, obj_type, call_name)
+
+    return refs, ambiguities
 
 
 def build_scoped_text_reference_seed_rows(
@@ -5690,7 +6182,7 @@ def build_scoped_text_reference_seed_rows(
         if type_u not in SCOPED_TEXT_REFERENCE_ELIGIBLE_TYPES:
             continue
         raw_text = raw_text or ""
-        cleaned_text = mask_sql_for_scan(raw_text).upper()
+        cleaned_text = mask_sql_for_reference_scan(raw_text).upper()
         dynamic_sql_texts_raw, dynamic_sql_ambiguities = _extract_dynamic_sql_literals_for_scan(raw_text)
         dynamic_sql_texts = [item.upper() for item in dynamic_sql_texts_raw]
         if not cleaned_text and not dynamic_sql_texts and not dynamic_sql_ambiguities:
@@ -5711,6 +6203,107 @@ def build_scoped_text_reference_seed_rows(
         elif diagnostic_rows is not None:
             for detail in dynamic_sql_ambiguities:
                 diagnostic_rows.append(("TEXT_REFERENCE_AMBIGUOUS", type_u, (node[0] or "").upper(), detail))
+    return rows
+
+
+def build_scoped_text_dependency_seed_rows(
+    scope_result: ScopedSourceScopeResult,
+    text_index: Dict[DependencyNode, str],
+    source_objects: SourceObjectMap,
+    pattern_index: Optional["ScopedPatternIndex"] = None,
+    diagnostic_rows: Optional[List[Tuple[str, str, str, str]]] = None,
+) -> List[Tuple[DependencyNode, str, str]]:
+    if not scope_result or not text_index:
+        return []
+    excluded_seed_nodes = {
+        ((full_u or "").upper(), (obj_type or "").upper())
+        for full_u, obj_type in (scope_result.excluded_nodes or frozenset())
+        if (full_u or "").strip() and (obj_type or "").strip()
+    }
+    candidate_types_by_full = build_scoped_candidate_types_by_full_from_nodes(
+        set(scope_result.excluded_nodes or frozenset()),
+        include_types=SCOPED_TEXT_REFERENCE_TARGET_TYPES,
+    )
+    pattern_index = (
+        pattern_index
+        or (ScopedPatternIndex(candidate_types_by_full) if candidate_types_by_full else None)
+    )
+    rows: List[Tuple[DependencyNode, str, str]] = []
+    seen: Set[DependencyNode] = set()
+    for node, raw_text in sorted((text_index or {}).items(), key=lambda item: (item[0][1], item[0][0])):
+        type_u = (node[1] or "").upper()
+        if type_u not in SCOPED_TEXT_REFERENCE_ELIGIBLE_TYPES:
+            continue
+        raw_text = raw_text or ""
+        cleaned_text = mask_sql_for_reference_scan(raw_text).upper()
+        dynamic_sql_texts_raw, dynamic_sql_ambiguities = _extract_dynamic_sql_literals_for_scan(raw_text)
+        scheduler_created_refs, scheduler_create_ambiguities = _extract_scheduler_created_object_refs(
+            raw_text,
+            (node[0].split('.', 1)[0].upper() if '.' in (node[0] or '') else ""),
+        )
+        dynamic_sql_texts = [item.upper() for item in dynamic_sql_texts_raw]
+        if (
+            not cleaned_text
+            and not dynamic_sql_texts
+            and not dynamic_sql_ambiguities
+            and not scheduler_created_refs
+            and not scheduler_create_ambiguities
+        ):
+            continue
+        node_owner = (node[0].split('.', 1)[0].upper() if '.' in (node[0] or '') else "")
+        text_tokens: Set[str] = set()
+        matches: List[str] = []
+        if pattern_index is not None:
+            text_tokens = pattern_index.extract_tokens(cleaned_text, dynamic_sql_texts)
+            matches = pattern_index.find_matches(
+                cleaned_text,
+                dynamic_sql_texts,
+                node_owner,
+                find_first=False,
+                text_tokens=text_tokens,
+            )
+        if diagnostic_rows is not None:
+            for detail in dynamic_sql_ambiguities:
+                diagnostic_rows.append(("TEXT_DEPENDENCY_AMBIGUOUS", type_u, (node[0] or "").upper(), detail))
+            for detail in scheduler_create_ambiguities:
+                diagnostic_rows.append(("SCHEDULER_CREATE_AMBIGUOUS", type_u, (node[0] or "").upper(), detail))
+        for matched_full in matches:
+            matched_type = _resolve_scoped_reference_dependency_type(source_objects, matched_full)
+            if not matched_type:
+                continue
+            seed_node = (matched_full, matched_type)
+            if seed_node in seen:
+                continue
+            rows.append((seed_node, "TEXT_DEPENDENCY_HEURISTIC", f"REFERENCED_BY:{type_u}:{(node[0] or '').upper()}"))
+            seen.add(seed_node)
+        for matched_full, matched_type, source_tag in scheduler_created_refs:
+            seed_node = (((matched_full or "").upper()), ((matched_type or "").upper()))
+            if seed_node not in excluded_seed_nodes:
+                continue
+            known_types = get_known_object_types(source_objects, matched_full)
+            if matched_type not in known_types:
+                if diagnostic_rows is not None:
+                    diagnostic_rows.append((
+                        "SCHEDULER_CREATE_TARGET_UNRESOLVED",
+                        type_u,
+                        (node[0] or "").upper(),
+                        "{source_tag}:{target}:{known}".format(
+                            source_tag=source_tag,
+                            target=(matched_full or "").upper(),
+                            known=",".join(sorted(known_types)) or "-",
+                        ),
+                    ))
+                continue
+            if seed_node in seen:
+                continue
+            rows.append((
+                seed_node,
+                "SCHEDULER_CREATE_HEURISTIC",
+                f"CREATED_BY:{type_u}:{(node[0] or '').upper()}:{source_tag}",
+            ))
+            seen.add(seed_node)
+        if not matches and not scheduler_created_refs:
+            continue
     return rows
 
 
@@ -7081,8 +7674,10 @@ def load_config(config_file: str) -> Tuple[OraConfig, ObConfig, Dict]:
         settings['config_dir'] = str(config_path.parent)
         settings['source_db_mode'] = source_db_mode
         settings['source_capabilities'] = source_capabilities
+        settings['source_support_tiers'] = build_ob_source_support_tier_matrix()
         settings['source_ob_cfg'] = source_ob_cfg
         settings['_source_mode_diagnostics'] = []
+        settings['_compatibility_default_diagnostics'] = []
         if source_db_mode == SOURCE_DB_MODE_OCEANBASE:
             required_ob_source_keys = ("executable", "host", "port", "user_string", "password")
             missing_ob_source_keys = [
@@ -7260,37 +7855,55 @@ def load_config(config_file: str) -> Tuple[OraConfig, ObConfig, Dict]:
         settings.setdefault('source_db_mode', source_db_mode)
 
         source_mode_diagnostics: List[str] = list(settings.get('_source_mode_diagnostics') or [])
+        compatibility_default_diagnostics: List[str] = list(settings.get('_compatibility_default_diagnostics') or [])
+        if not config.has_option("SETTINGS", "report_to_db"):
+            compatibility_default_diagnostics.append(
+                "report_to_db 未配置，当前默认按 false 处理；如依赖 report_db，请显式设置 report_to_db=true。"
+            )
         if source_db_mode == SOURCE_DB_MODE_OCEANBASE:
-            if (settings.get('object_created_before') or '').strip():
-                raise ValueError("source_db_mode=oceanbase 当前不支持 object_created_before")
             scope_mode_raw = normalize_source_object_scope_mode(
                 settings.get('source_object_scope_mode', 'full_source')
             )
+            source_mode_diagnostics.append(
+                "source_db_mode=oceanbase：OB->OB product mode 已启用；功能按 support tiers/capability matrix 运行。"
+            )
+            if (settings.get('object_created_before') or '').strip():
+                source_mode_diagnostics.append(
+                    "source_db_mode=oceanbase：object_created_before 已配置，将按源端 OceanBase CREATED 元数据执行范围过滤。"
+                )
             if scope_mode_raw != 'full_source':
-                raise ValueError(
-                    "source_db_mode=oceanbase 当前仅支持 source_object_scope_mode=full_source"
+                source_mode_diagnostics.append(
+                    f"source_db_mode=oceanbase：source_object_scope_mode={scope_mode_raw}。"
+                )
+            if (
+                scope_mode_raw == 'remap_root_closure'
+                and not config.has_option("SETTINGS", "remap_scope_text_fallback_mode")
+            ):
+                settings['remap_scope_text_fallback_mode'] = 'safe'
+                source_mode_diagnostics.append(
+                    "source_db_mode=oceanbase：remap_root_closure 未显式配置 remap_scope_text_fallback_mode，默认按 safe 文本补盲执行。"
+                )
+            elif scope_mode_raw == 'explicit_roots':
+                source_mode_diagnostics.append(
+                    "source_db_mode=oceanbase：explicit_roots 仅保留 remap_file 中显式 roots 及其附属对象，不做依赖闭包扩展。"
                 )
             if parse_bool_flag(settings.get('generate_grants', 'true'), True):
-                settings['generate_grants'] = 'false'
                 source_mode_diagnostics.append(
-                    "source_db_mode=oceanbase：当前未启用 OB 源端授权生成，已自动关闭 generate_grants。"
+                    "source_db_mode=oceanbase：已启用 OB 源端授权生成。"
                 )
             if parse_bool_flag(settings.get('generate_fixup', 'true'), True):
                 source_mode_diagnostics.append(
                     "source_db_mode=oceanbase：已启用 OB->OB fixup；当前仅放开 certified structural/code-object families，未认证对象族会转 deferred/manual。"
                 )
             if parse_bool_flag(settings.get('check_object_usability', 'false'), False):
-                settings['check_object_usability'] = 'false'
-                settings['check_source_usability'] = 'false'
                 source_mode_diagnostics.append(
-                    "source_db_mode=oceanbase：当前未启用 source usability 探针，已自动关闭 check_object_usability/check_source_usability。"
+                    "source_db_mode=oceanbase：已启用 source usability 探针。"
                 )
             if normalize_table_data_presence_check_mode(
                 settings.get('table_data_presence_check', 'auto')
             ) != 'off':
-                settings['table_data_presence_check'] = 'off'
                 source_mode_diagnostics.append(
-                    "source_db_mode=oceanbase：当前未启用表数据存在性风险校验，已自动关闭 table_data_presence_check。"
+                    "source_db_mode=oceanbase：已启用表数据存在性风险校验。"
                 )
             if settings.get('blacklist_mode', 'auto').strip().lower() != 'disabled':
                 source_mode_diagnostics.append(
@@ -7305,6 +7918,7 @@ def load_config(config_file: str) -> Tuple[OraConfig, ObConfig, Dict]:
                     "source_db_mode=oceanbase：synonym_fixup_scope 未配置，默认按 all 处理。"
                 )
         settings['_source_mode_diagnostics'] = source_mode_diagnostics
+        settings['_compatibility_default_diagnostics'] = dedupe_preserve_order(compatibility_default_diagnostics)
 
         enabled_primary_types = parse_type_list(
             settings.get('check_primary_types', ''),
@@ -8192,7 +8806,7 @@ def run_config_wizard(config_path: Path) -> None:
         normalized = GTT_TABLE_HANDLING_MODE_ALIASES.get(val.strip().lower(), val.strip().lower())
         if normalized in GTT_TABLE_HANDLING_MODE_VALUES:
             return True, ""
-        return False, "仅支持 rewrite_to_normal/preserve_original/blocked"
+        return False, "仅支持 auto/rewrite_to_normal/preserve_original/blocked"
 
     def _validate_context_fixup_mode(val: str) -> Tuple[bool, str]:
         if not val.strip():
@@ -8283,7 +8897,7 @@ def run_config_wizard(config_path: Path) -> None:
         normalized = SOURCE_OBJECT_SCOPE_MODE_ALIASES.get(val.strip().lower(), val.strip().lower())
         if normalized in SOURCE_OBJECT_SCOPE_MODE_VALUES:
             return True, ""
-        return False, "仅支持 full_source/remap_root_closure"
+        return False, "仅支持 full_source/explicit_roots/remap_root_closure"
 
     def _validate_remap_scope_text_fallback_mode(val: str) -> Tuple[bool, str]:
         if not val.strip():
@@ -8514,7 +9128,7 @@ def run_config_wizard(config_path: Path) -> None:
     _prompt_field(
         "SETTINGS",
         "gtt_table_handling_mode",
-        "GTT 处理模式 (rewrite_to_normal/preserve_original/blocked)",
+        "GTT 处理模式 (auto/rewrite_to_normal/preserve_original/blocked)",
         default=cfg.get("SETTINGS", "gtt_table_handling_mode", fallback="rewrite_to_normal"),
         validator=_validate_gtt_table_handling_mode,
         transform=normalize_gtt_table_handling_mode,
@@ -9059,7 +9673,7 @@ def run_config_wizard(config_path: Path) -> None:
     _prompt_field(
         "SETTINGS",
         "source_object_scope_mode",
-        "源对象范围模式 (full_source/remap_root_closure)",
+        "源对象范围模式 (full_source/explicit_roots/remap_root_closure)",
         default=cfg.get("SETTINGS", "source_object_scope_mode", fallback="full_source"),
         validator=_validate_source_object_scope_mode,
         transform=normalize_source_object_scope_mode,
@@ -10080,7 +10694,7 @@ def collect_constraint_status_drift_rows(
             entry["cols"] = tuple(col.upper() for col in (cons_meta.get("columns") or []) if col)
         elif ctype == "C":
             entry["expr_key"] = key[1] if len(key) > 1 else ""
-            entry["notnull_col"] = normalize_identifier_name(_extract_notnull_column(cons_meta.get("search_condition")))
+            entry["notnull_col"] = normalize_semantic_identifier_name(_extract_notnull_column(cons_meta.get("search_condition")))
             entry["is_system_named"] = is_system_notnull_check(
                 cons_name_u,
                 cons_meta.get("search_condition"),
@@ -10185,12 +10799,12 @@ def collect_constraint_status_drift_rows(
                 if normalize_identifier_name(entry.constraint_name) not in used_tgt_names
             ]
             if available_entries:
-                remaining_notnull_groups[col_u.upper()] = available_entries
+                remaining_notnull_groups[normalize_semantic_identifier_name(col_u)] = available_entries
 
         for src_entry in sorted(unmatched_src, key=lambda e: (str(e.get("type") or ""), str(e.get("name") or ""))):
             if str(src_entry.get("type") or "").upper() != "C":
                 continue
-            notnull_col = normalize_identifier_name(src_entry.get("notnull_col"))
+            notnull_col = normalize_semantic_identifier_name(src_entry.get("notnull_col"))
             if not notnull_col:
                 continue
             target_entries = remaining_notnull_groups.get(notnull_col)
@@ -10918,6 +11532,7 @@ def build_source_scope_closure(
             excluded_nodes=frozenset(),
             detail_rows=(),
         )
+    dependency_closure_enabled = (mode == "remap_root_closure")
 
     all_nodes = collect_source_object_nodes(source_objects)
     reverse_attached = build_attached_object_reverse_map(source_objects, object_parent_map)
@@ -10976,16 +11591,17 @@ def build_source_scope_closure(
         for child_node in reverse_attached_sorted.get(full_u, ()):
             _queue(child_node, "ATTACHED_OBJECT", "%s:%s" % (type_u, full_u))
 
-        for ref_full, ref_type in dependency_graph_sorted.get((full_u, type_u), ()):
-            _queue((ref_full.upper(), ref_type.upper()), "DEPENDENCY", "%s:%s" % (type_u, full_u))
+        if dependency_closure_enabled:
+            for ref_full, ref_type in dependency_graph_sorted.get((full_u, type_u), ()):
+                _queue((ref_full.upper(), ref_type.upper()), "DEPENDENCY", "%s:%s" % (type_u, full_u))
 
-        reverse_edges = reverse_dependency_graph_sorted.get((full_u, type_u), ())
-        if should_expand_reverse_dependency(type_u):
-            for dep_full, dep_type in reverse_edges:
-                _queue((dep_full.upper(), dep_type.upper()), "REVERSE_DEPENDENCY", "%s:%s" % (type_u, full_u))
-        else:
-            for dep_full, dep_type in reverse_edges:
-                blocked_reverse_nodes[((dep_full or "").upper(), (dep_type or "").upper())] = f"REVERSE_DEPENDENCY_BOUNDARY:{type_u}:{full_u}"
+            reverse_edges = reverse_dependency_graph_sorted.get((full_u, type_u), ())
+            if should_expand_reverse_dependency(type_u):
+                for dep_full, dep_type in reverse_edges:
+                    _queue((dep_full.upper(), dep_type.upper()), "REVERSE_DEPENDENCY", "%s:%s" % (type_u, full_u))
+            else:
+                for dep_full, dep_type in reverse_edges:
+                    blocked_reverse_nodes[((dep_full or "").upper(), (dep_type or "").upper())] = f"REVERSE_DEPENDENCY_BOUNDARY:{type_u}:{full_u}"
 
     excluded_nodes = all_nodes - included_nodes
     for full_u, type_u in sorted(excluded_nodes, key=lambda item: (item[1], item[0])):
@@ -10993,7 +11609,12 @@ def build_source_scope_closure(
         if boundary_detail:
             detail_rows.append(("REVERSE_BOUNDARY_SKIPPED", type_u, full_u, boundary_detail))
         else:
-            detail_rows.append(("FILTERED_OUT", type_u, full_u, "OUTSIDE_REMAP_ROOT_CLOSURE"))
+            detail_rows.append((
+                "FILTERED_OUT",
+                type_u,
+                full_u,
+                "OUTSIDE_REMAP_ROOT_CLOSURE" if dependency_closure_enabled else "OUTSIDE_EXPLICIT_ROOTS",
+            ))
 
     return ScopedSourceScopeResult(
         mode=mode,
@@ -11391,7 +12012,7 @@ def build_job_action_dependency_records(
         if cached is not None:
             return list(cached)
         raw_text = raw_text or ""
-        cleaned_text = mask_sql_for_scan(raw_text).upper()
+        cleaned_text = mask_sql_for_reference_scan(raw_text).upper()
         dynamic_sql_texts_raw, _dynamic_sql_ambiguities = _extract_dynamic_sql_literals_for_scan(raw_text or "")
         dynamic_sql_texts = [item.upper() for item in dynamic_sql_texts_raw]
         text_tokens = pattern_index.extract_tokens(cleaned_text, dynamic_sql_texts)
@@ -11578,7 +12199,7 @@ def build_job_action_dependency_records_with_loader(
         if cached is not None:
             return list(cached)
         raw_text = raw_text or ""
-        cleaned_text = mask_sql_for_scan(raw_text).upper()
+        cleaned_text = mask_sql_for_reference_scan(raw_text).upper()
         dynamic_sql_texts_raw, _dynamic_sql_ambiguities = _extract_dynamic_sql_literals_for_scan(raw_text or "")
         dynamic_sql_texts = [item.upper() for item in dynamic_sql_texts_raw]
         text_tokens = pattern_index.extract_tokens(cleaned_text, dynamic_sql_texts)
@@ -11759,6 +12380,31 @@ def load_oracle_job_action_dependency_records(
     return rows
 
 
+def load_ob_job_action_dependency_records(
+    ob_cfg: ObConfig,
+    source_objects: Optional[SourceObjectMap],
+    runtime_degraded_events: Optional[List[RuntimeDegradedEvent]] = None,
+) -> List[DependencyRecord]:
+    source_objects = source_objects or {}
+    job_nodes = collect_job_action_candidate_nodes(source_objects)
+    if not job_nodes:
+        return []
+
+    log.info('[PERF] JOB_ACTION candidate_nodes: jobs=%d', len(job_nodes))
+
+    def _loader(candidate_nodes: Set[DependencyNode]) -> Dict[DependencyNode, str]:
+        return load_ob_scoped_text_reference_index(ob_cfg, candidate_nodes)
+
+    rows = build_job_action_dependency_records_with_loader(
+        source_objects,
+        _loader,
+        runtime_degraded_events=runtime_degraded_events,
+    )
+    if rows:
+        log.info('[SOURCE_SCOPE] 已从 OB JOB_ACTION 补充 JOB 依赖 %d 条。', len(rows))
+    return rows
+
+
 def load_oracle_scoped_text_reference_index(
     ora_cfg: OraConfig,
     candidate_nodes: Set[DependencyNode],
@@ -11863,21 +12509,28 @@ def load_oracle_scoped_text_reference_index(
 def load_oracle_context_inventory(
     ora_cfg: OraConfig,
     allowed_schemas: Optional[Set[str]] = None,
-) -> Tuple[Dict[str, ContextMetadata], Optional[str]]:
+) -> Tuple[Dict[str, ContextMetadata], Optional[str], str]:
     contexts: Dict[str, ContextMetadata] = {}
     schema_filter = sorted({normalize_identifier_name(item) for item in (allowed_schemas or set()) if item})
-    query_specs: Tuple[str, ...] = (
-        """
-        SELECT NAMESPACE, SCHEMA, PACKAGE, TYPE, TRACKING, ORIGIN_CON_ID
-        FROM DBA_CONTEXT
-        {where_clause}
-        """,
-        """
-        SELECT NAMESPACE, SCHEMA, PACKAGE, TYPE, '' AS TRACKING, NULL AS ORIGIN_CON_ID
-        FROM DBA_CONTEXT
-        {where_clause}
-        """,
+    query_specs: Tuple[Tuple[str, str], ...] = (
+        (
+            "full_columns",
+            """
+            SELECT NAMESPACE, SCHEMA, PACKAGE, TYPE, TRACKING, ORIGIN_CON_ID
+            FROM DBA_CONTEXT
+            {where_clause}
+            """,
+        ),
+        (
+            "fallback_columns",
+            """
+            SELECT NAMESPACE, SCHEMA, PACKAGE, TYPE, '' AS TRACKING, NULL AS ORIGIN_CON_ID
+            FROM DBA_CONTEXT
+            {where_clause}
+            """,
+        ),
     )
+    degraded_events: List[str] = []
     try:
         with oracledb.connect(
             user=ora_cfg['user'],
@@ -11886,26 +12539,22 @@ def load_oracle_context_inventory(
         ) as connection:
             with connection.cursor() as cursor:
                 apply_oracle_cursor_fetch_tuning(cursor, "medium_metadata")
-                for sql_tpl in query_specs:
-                    try:
-                        if schema_filter:
-                            for chunk in chunk_list(schema_filter, ORACLE_IN_BATCH_SIZE):
+                remaining_chunks: List[Optional[List[str]]]
+                if schema_filter:
+                    remaining_chunks = [chunk for chunk in chunk_list(schema_filter, ORACLE_IN_BATCH_SIZE)]
+                else:
+                    remaining_chunks = [None]
+                for template_name, sql_tpl in query_specs:
+                    if not remaining_chunks:
+                        break
+                    next_remaining: List[Optional[List[str]]] = []
+                    for chunk in remaining_chunks:
+                        try:
+                            if chunk is None:
+                                cursor.execute(sql_tpl.format(where_clause=""))
+                            else:
                                 where_clause = f"WHERE SCHEMA IN ({build_bind_placeholders(len(chunk))})"
                                 cursor.execute(sql_tpl.format(where_clause=where_clause), chunk)
-                                for row in cursor:
-                                    namespace_u = normalize_identifier_name(row[0])
-                                    if not namespace_u:
-                                        continue
-                                    contexts[namespace_u] = ContextMetadata(
-                                        namespace=namespace_u,
-                                        schema=normalize_identifier_name(row[1]) or "",
-                                        package=normalize_identifier_name(row[2]) or "",
-                                        type=normalize_context_inventory_type(row[3]),
-                                        tracking=str(row[4] or ""),
-                                        origin_con_id=str(row[5] or ""),
-                                    )
-                        else:
-                            cursor.execute(sql_tpl.format(where_clause=""))
                             for row in cursor:
                                 namespace_u = normalize_identifier_name(row[0])
                                 if not namespace_u:
@@ -11918,20 +12567,40 @@ def load_oracle_context_inventory(
                                     tracking=str(row[4] or ""),
                                     origin_con_id=str(row[5] or ""),
                                 )
-                        return contexts, None
-                    except oracledb.Error as exc:
-                        log.debug("load_oracle_context_inventory 降级: %s", exc)
-                        contexts.clear()
-                        continue
+                        except oracledb.Error as exc:
+                            log.debug("load_oracle_context_inventory 降级: %s", exc)
+                            degraded_events.append(
+                                "{template}:{scope}:{error}".format(
+                                    template=template_name,
+                                    scope="ALL" if chunk is None else ",".join(chunk),
+                                    error=normalize_error_text(exc),
+                                )
+                            )
+                            next_remaining.append(chunk)
+                    remaining_chunks = next_remaining
+                if not remaining_chunks:
+                    if degraded_events:
+                        return (
+                            contexts,
+                            "fallback_to_simplified_dba_context: " + " | ".join(degraded_events[:4]),
+                            CONTEXT_INVENTORY_HEALTH_DEGRADED,
+                        )
+                    return contexts, None, CONTEXT_INVENTORY_HEALTH_HEALTHY
     except oracledb.Error as exc:
-        return {}, normalize_error_text(exc)
-    return {}, "read_dba_context_failed"
+        return {}, normalize_error_text(exc), CONTEXT_INVENTORY_HEALTH_FAILED
+    if contexts:
+        return (
+            contexts,
+            "partial_context_inventory: " + (" | ".join(degraded_events[:4]) if degraded_events else "read_dba_context_failed"),
+            CONTEXT_INVENTORY_HEALTH_DEGRADED,
+        )
+    return {}, "read_dba_context_failed", CONTEXT_INVENTORY_HEALTH_FAILED
 
 
 def load_ob_context_inventory(
     ob_cfg: ObConfig,
     allowed_schemas: Optional[Set[str]] = None,
-) -> Tuple[Dict[str, ContextMetadata], Optional[str]]:
+) -> Tuple[Dict[str, ContextMetadata], Optional[str], str]:
     contexts: Dict[str, ContextMetadata] = {}
     schema_filter = sorted({normalize_identifier_name(item) for item in (allowed_schemas or set()) if item})
     support_tracking = ob_has_dba_column(ob_cfg, "DBA_CONTEXT", "TRACKING")
@@ -11951,7 +12620,7 @@ def load_ob_context_inventory(
             quiet_error=True,
         )
         if not ok:
-            return {}, normalize_error_text(err)
+            return {}, normalize_error_text(err), CONTEXT_INVENTORY_HEALTH_FAILED
     else:
         sql = f"""
             SELECT NAMESPACE, SCHEMA, PACKAGE, TYPE{tracking_col}{origin_col}
@@ -11959,7 +12628,7 @@ def load_ob_context_inventory(
         """
         ok, out, err = obclient_run_sql(ob_cfg, sql, quiet_error=True)
         if not ok:
-            return {}, normalize_error_text(err)
+            return {}, normalize_error_text(err), CONTEXT_INVENTORY_HEALTH_FAILED
         lines = (out or "").splitlines()
     for line in lines:
         parts = line.split('\t')
@@ -11976,7 +12645,7 @@ def load_ob_context_inventory(
             tracking=str(parts[4] or "") if len(parts) > 4 else "",
             origin_con_id=str(parts[5] or "") if len(parts) > 5 else "",
         )
-    return contexts, None
+    return contexts, None, CONTEXT_INVENTORY_HEALTH_HEALTHY
 
 
 _SYS_CONTEXT_LITERAL_RE = re.compile(
@@ -11991,26 +12660,75 @@ _SET_CONTEXT_LITERAL_RE = re.compile(
 _SET_CONTEXT_CALL_RE = re.compile(r"DBMS_SESSION\s*\.\s*SET_CONTEXT\s*\(", flags=re.IGNORECASE)
 
 
+def _extract_named_or_positional_call_arg(
+    args: Sequence[str],
+    *,
+    position: int,
+    names: Sequence[str] = (),
+) -> str:
+    for name in names:
+        pattern = re.compile(rf"(?is)^{re.escape(name)}\s*=>")
+        for arg in args:
+            stripped = (arg or "").strip()
+            if pattern.match(stripped):
+                return pattern.sub("", stripped, count=1).strip()
+    if position < len(args):
+        return (args[position] or "").strip()
+    return ""
+
+
+def _decode_static_string_call_arg(expr: str) -> Optional[str]:
+    stripped = (expr or "").strip()
+    if not stripped:
+        return None
+    match = re.match(r"^'((?:''|[^'])*)'$", stripped, flags=re.DOTALL)
+    if not match:
+        return None
+    return match.group(1).replace("''", "'")
+
+
 def extract_context_reference_rows(
     object_full: str,
     object_type: str,
     text: Optional[str],
 ) -> List[ContextReferenceRow]:
-    sql_text = strip_sql_comments_outside_literals(text).strip()
-    if not sql_text:
+    sql_text = str(text or "")
+    if not sql_text.strip():
         return []
+    masked_sql = mask_sql_for_scan(sql_text)
 
     def _decode_literal(value: str) -> str:
         return normalize_identifier_name(value.replace("''", "'")) or ""
 
     rows: List[ContextReferenceRow] = []
 
-    def _collect(literal_re: re.Pattern, call_re: re.Pattern, reference_kind: str) -> None:
-        literal_starts: Set[int] = set()
-        for match in literal_re.finditer(sql_text):
-            literal_starts.add(match.start())
-            namespace_u = _decode_literal(match.group(1))
-            attribute_u = _decode_literal(match.group(2))
+    def _collect(call_re: re.Pattern, reference_kind: str) -> None:
+        for match in call_re.finditer(masked_sql):
+            open_pos = masked_sql.find("(", match.start())
+            if open_pos == -1:
+                continue
+            args = _split_top_level_call_arguments(sql_text, open_pos, masked_sql)
+            if reference_kind == "SYS_CONTEXT":
+                namespace_expr = _extract_named_or_positional_call_arg(args, position=0, names=("namespace",))
+                attribute_expr = _extract_named_or_positional_call_arg(args, position=1, names=("parameter", "attribute"))
+            else:
+                namespace_expr = _extract_named_or_positional_call_arg(args, position=0, names=("namespace",))
+                attribute_expr = _extract_named_or_positional_call_arg(args, position=1, names=("attribute",))
+            namespace_literal = _decode_static_string_call_arg(namespace_expr)
+            attribute_literal = _decode_static_string_call_arg(attribute_expr)
+            if namespace_literal is None:
+                rows.append(ContextReferenceRow(
+                    object_full=(object_full or "").upper(),
+                    object_type=(object_type or "").upper(),
+                    reference_kind=reference_kind,
+                    namespace="<dynamic>",
+                    attribute="",
+                    status="UNRESOLVED",
+                    detail="namespace expression is not a string literal",
+                ))
+                continue
+            namespace_u = _decode_literal(namespace_literal)
+            attribute_u = _decode_literal(attribute_literal or "")
             if not namespace_u or namespace_u in CONTEXT_REFERENCE_BUILTIN_NAMESPACES:
                 continue
             rows.append(ContextReferenceRow(
@@ -12022,21 +12740,9 @@ def extract_context_reference_rows(
                 status="LITERAL",
                 detail="",
             ))
-        for match in call_re.finditer(sql_text):
-            if match.start() in literal_starts:
-                continue
-            rows.append(ContextReferenceRow(
-                object_full=(object_full or "").upper(),
-                object_type=(object_type or "").upper(),
-                reference_kind=reference_kind,
-                namespace="<dynamic>",
-                attribute="",
-                status="UNRESOLVED",
-                detail="namespace expression is not a string literal",
-            ))
 
-    _collect(_SYS_CONTEXT_LITERAL_RE, _SYS_CONTEXT_CALL_RE, "SYS_CONTEXT")
-    _collect(_SET_CONTEXT_LITERAL_RE, _SET_CONTEXT_CALL_RE, "SET_CONTEXT")
+    _collect(_SYS_CONTEXT_CALL_RE, "SYS_CONTEXT")
+    _collect(_SET_CONTEXT_CALL_RE, "SET_CONTEXT")
 
     dedup: Dict[Tuple[str, str, str, str, str, str], ContextReferenceRow] = {}
     for row in rows:
@@ -12077,6 +12783,8 @@ def load_ob_scoped_text_reference_index(
         if obj_type_u == "VIEW":
             view_tuple = ob_get_view_text(ob_cfg, owner_u, name_u)
             text_value = view_tuple[0] if view_tuple else None
+        elif obj_type_u == "JOB":
+            text_value = ob_get_job_action(ob_cfg, owner_u, name_u)
         elif obj_type_u in {"PROCEDURE", "FUNCTION", "PACKAGE", "PACKAGE BODY", "TRIGGER", "TYPE BODY"}:
             text_value = ob_get_source_text(ob_cfg, obj_type_u, owner_u, name_u)
         if text_value:
@@ -12223,6 +12931,9 @@ def build_context_compare_results(
     context_fixup_mode: str,
     target_package_objects: Optional[Set[str]] = None,
     planned_package_targets: Optional[Set[str]] = None,
+    target_package_statuses: Optional[Dict[str, str]] = None,
+    source_inventory_health: str = CONTEXT_INVENTORY_HEALTH_HEALTHY,
+    target_inventory_health: str = CONTEXT_INVENTORY_HEALTH_HEALTHY,
 ) -> ContextCompareResults:
     inventory_enabled = "CONTEXT" in {t.upper() for t in (enabled_primary_types or set())}
     literal_refs = [row for row in (reference_rows or []) if row.status == "LITERAL"]
@@ -12232,6 +12943,11 @@ def build_context_compare_results(
         namespaces_to_check.update(normalize_identifier_name(name) for name in (source_contexts or {}).keys() if name)
     target_pkg_set = {str(item or "").upper() for item in (target_package_objects or set()) if item}
     planned_pkg_set = {str(item or "").upper() for item in (planned_package_targets or set()) if item}
+    target_pkg_statuses = {
+        str(full_name or "").upper(): str(status or "").upper()
+        for full_name, status in ((target_package_statuses or {}).items())
+        if str(full_name or "").strip()
+    }
     fixup_mode = normalize_context_fixup_mode(context_fixup_mode)
     missing_support_rows: List[ObjectSupportReportRow] = []
     unsupported_rows: List[ObjectSupportReportRow] = []
@@ -12239,6 +12955,12 @@ def build_context_compare_results(
     runnable_fixups: List[ContextFixupRow] = []
     manual_fixups: List[ContextFixupRow] = []
     namespace_status: Dict[str, Tuple[str, str, str]] = {}
+    inventory_health = CONTEXT_INVENTORY_HEALTH_HEALTHY
+    if (
+        source_inventory_health != CONTEXT_INVENTORY_HEALTH_HEALTHY
+        or target_inventory_health != CONTEXT_INVENTORY_HEALTH_HEALTHY
+    ):
+        inventory_health = CONTEXT_INVENTORY_HEALTH_DEGRADED
 
     source_ctx_norm = {normalize_identifier_name(k): v for k, v in (source_contexts or {}).items() if normalize_identifier_name(k)}
     target_ctx_norm = {normalize_identifier_name(k): v for k, v in (target_contexts or {}).items() if normalize_identifier_name(k)}
@@ -12248,6 +12970,7 @@ def build_context_compare_results(
         src_meta = source_ctx_norm.get(namespace_u)
         tgt_meta = target_ctx_norm.get(namespace_u)
         if src_meta is None:
+            degraded_source_inventory = source_inventory_health != CONTEXT_INVENTORY_HEALTH_HEALTHY
             detail_rows.append(ContextDriftDetailRow(
                 namespace=namespace_u,
                 source_binding="-",
@@ -12255,13 +12978,21 @@ def build_context_compare_results(
                 target_binding=format_context_binding(tgt_meta.schema, tgt_meta.package) if tgt_meta else "-",
                 source_mode="-",
                 target_mode=normalize_context_inventory_type(tgt_meta.type) if tgt_meta else "-",
-                status="SOURCE_CONTEXT_MISSING",
-                reason_code="SOURCE_CONTEXT_METADATA_MISSING",
-                reason="源端代码引用了 context，但源端 DBA_CONTEXT 未发现 namespace。",
+                status="SOURCE_CONTEXT_UNVERIFIED" if degraded_source_inventory else "SOURCE_CONTEXT_MISSING",
+                reason_code="SOURCE_CONTEXT_INVENTORY_DEGRADED" if degraded_source_inventory else "SOURCE_CONTEXT_METADATA_MISSING",
+                reason=(
+                    "源端 context inventory 已降级，当前无法确认该 namespace 是否真的缺失。"
+                    if degraded_source_inventory else
+                    "源端代码引用了 context，但源端 DBA_CONTEXT 未发现 namespace。"
+                ),
                 action="人工确认源端 CREATE CONTEXT 定义",
-                detail="reference-driven validation only",
+                detail="source_inventory_degraded" if degraded_source_inventory else "reference-driven validation only",
             ))
-            namespace_status[namespace_u] = ("SOURCE_CONTEXT_MISSING", "SOURCE_CONTEXT_METADATA_MISSING", "人工确认源端 CREATE CONTEXT 定义")
+            namespace_status[namespace_u] = (
+                "SOURCE_CONTEXT_UNVERIFIED" if degraded_source_inventory else "SOURCE_CONTEXT_MISSING",
+                "SOURCE_CONTEXT_INVENTORY_DEGRADED" if degraded_source_inventory else "SOURCE_CONTEXT_METADATA_MISSING",
+                "人工确认源端 CREATE CONTEXT 定义",
+            )
             continue
 
         expected_meta, trusted_pkg_out_of_scope, source_pkg_full = resolve_expected_context_metadata(src_meta, full_object_mapping)
@@ -12278,6 +13009,12 @@ def build_context_compare_results(
                 else:
                     trusted_package_ready = False
                     prerequisite = f"trusted package missing: {expected_binding}"
+            elif (
+                expected_binding in target_pkg_statuses
+                and target_pkg_statuses.get(expected_binding) not in {"", "VALID"}
+            ):
+                trusted_package_ready = False
+                prerequisite = f"trusted package invalid: {expected_binding}"
 
         if tgt_meta is None:
             if trusted_pkg_out_of_scope and source_pkg_full:
@@ -12435,6 +13172,7 @@ def build_context_compare_results(
             tgt_meta = target_ctx_norm.get(namespace_u)
             target_binding = format_context_binding(tgt_meta.schema, tgt_meta.package) if tgt_meta else "-"
             target_mode = normalize_context_inventory_type(tgt_meta.type) if tgt_meta else "-"
+            degraded_source_inventory = source_inventory_health != CONTEXT_INVENTORY_HEALTH_HEALTHY
             detail_row = ContextDriftDetailRow(
                 namespace=namespace_u,
                 source_binding="-",
@@ -12442,11 +13180,19 @@ def build_context_compare_results(
                 target_binding=target_binding,
                 source_mode="-",
                 target_mode=target_mode,
-                status="EXTRA_TARGET",
-                reason_code="TARGET_CONTEXT_EXTRA",
-                reason="目标端存在源端未定义的 application context。",
+                status="EXTRA_TARGET_UNVERIFIED" if degraded_source_inventory else "EXTRA_TARGET",
+                reason_code="TARGET_CONTEXT_EXTRA_UNVERIFIED" if degraded_source_inventory else "TARGET_CONTEXT_EXTRA",
+                reason=(
+                    "源端 context inventory 已降级，目标端该 context 当前只能保守标记为待确认。"
+                    if degraded_source_inventory else
+                    "目标端存在源端未定义的 application context。"
+                ),
                 action="人工确认是否需要删除目标端 context",
-                detail=f"target_binding={target_binding}; target_mode={target_mode}",
+                detail=(
+                    f"target_binding={target_binding}; target_mode={target_mode}; source_inventory={source_inventory_health}"
+                    if degraded_source_inventory else
+                    f"target_binding={target_binding}; target_mode={target_mode}"
+                ),
                 prerequisite="",
             )
             detail_rows.append(detail_row)
@@ -12462,7 +13208,7 @@ def build_context_compare_results(
                 detail=detail_row.detail,
                 root_cause=f"{namespace_u}({detail_row.reason_code})",
             ))
-            namespace_status[namespace_u] = ("EXTRA_TARGET", detail_row.reason_code, detail_row.action)
+            namespace_status[namespace_u] = (detail_row.status, detail_row.reason_code, detail_row.action)
 
     reference_detail_rows: List[ContextReferenceRow] = []
     for row in literal_refs:
@@ -12488,6 +13234,7 @@ def build_context_compare_results(
         "unresolved": len(unresolved_refs),
         "runnable": len(runnable_fixups),
         "manual": len(manual_fixups),
+        "inventory_health": inventory_health,
     }
     return ContextCompareResults(
         missing_support_rows=missing_support_rows,
@@ -12511,7 +13258,18 @@ def extend_source_scope_result_with_seed_rows(
 ) -> ScopedSourceScopeResult:
     if not seed_rows:
         return scope_result
-    extra_seed_nodes = {node for node, _status, _detail in seed_rows}
+    blocked_seed_nodes = {
+        ((full_u or "").upper(), (obj_type or "").upper())
+        for status, obj_type, full_u, _detail in (scope_result.detail_rows or ())
+        if status == "REVERSE_BOUNDARY_SKIPPED"
+    }
+    extra_seed_nodes = {
+        ((node[0] or "").upper(), (node[1] or "").upper())
+        for node, _status, _detail in seed_rows
+        if ((node[0] or "").upper(), (node[1] or "").upper()) not in blocked_seed_nodes
+    }
+    if not extra_seed_nodes:
+        return scope_result
     extra_result = build_source_scope_closure(
         source_objects,
         dependency_graph,
@@ -12531,6 +13289,8 @@ def extend_source_scope_result_with_seed_rows(
     for status, obj_type, full_u, detail in (extra_result.detail_rows or ()):
         node_key = ((full_u or "").upper(), (obj_type or "").upper())
         if node_key in existing_nodes:
+            continue
+        if node_key in blocked_seed_nodes:
             continue
         if status in {"FILTERED_OUT", "REVERSE_BOUNDARY_SKIPPED"}:
             continue
@@ -12557,6 +13317,7 @@ MAX_SCOPED_TEXT_FALLBACK_ROUNDS = 50
 
 
 def apply_scoped_text_reference_fallback(
+    settings: Dict,
     ora_cfg: OraConfig,
     scope_result: ScopedSourceScopeResult,
     source_objects: SourceObjectMap,
@@ -12567,7 +13328,9 @@ def apply_scoped_text_reference_fallback(
     max_rounds: int = MAX_SCOPED_TEXT_FALLBACK_ROUNDS,
 ) -> Tuple[ScopedSourceScopeResult, int]:
     total_added = 0
-    pattern_index = ScopedPatternIndex(
+    source_db_mode = normalize_source_db_mode((settings or {}).get("source_db_mode", SOURCE_DB_MODE_ORACLE))
+    source_ob_cfg = (settings or {}).get("source_ob_cfg") or {}
+    reverse_pattern_index = ScopedPatternIndex(
         build_scoped_candidate_types_by_full_from_nodes(
             set(scope_result.included_nodes or frozenset()),
             include_types=SCOPED_TEXT_REFERENCE_TARGET_TYPES,
@@ -12575,26 +13338,64 @@ def apply_scoped_text_reference_fallback(
     )
     log.info(
         '[PERF] SAFE_TEXT pattern_index init: candidates=%d, name_buckets=%d, slow_candidates=%d',
-        pattern_index.candidate_count,
-        pattern_index.name_bucket_count,
-        pattern_index.slow_candidate_count,
+        reverse_pattern_index.candidate_count,
+        reverse_pattern_index.name_bucket_count,
+        reverse_pattern_index.slow_candidate_count,
     )
+
+    def _load_source_text_index(candidate_nodes: Set[DependencyNode]) -> Dict[DependencyNode, str]:
+        if source_db_mode == SOURCE_DB_MODE_OCEANBASE:
+            return load_ob_scoped_text_reference_index(source_ob_cfg, candidate_nodes)
+        return load_oracle_scoped_text_reference_index(ora_cfg, candidate_nodes)
+
+    attempted_text_nodes: Set[DependencyNode] = set()
+    text_index_cache: Dict[DependencyNode, str] = {}
+
+    def _load_cached_source_text_index(candidate_nodes: Set[DependencyNode]) -> Dict[DependencyNode, str]:
+        normalized_candidates = {
+            ((full_u or "").upper(), (obj_type or "").upper())
+            for full_u, obj_type in (candidate_nodes or set())
+            if (full_u or "").strip() and (obj_type or "").strip()
+        }
+        pending_nodes = normalized_candidates - attempted_text_nodes
+        if pending_nodes:
+            text_index_cache.update(_load_source_text_index(pending_nodes))
+            attempted_text_nodes.update(pending_nodes)
+        return {
+            node: text_index_cache[node]
+            for node in normalized_candidates
+            if node in text_index_cache
+        }
+
     for _round in range(max_rounds):
-        scoped_text_index = load_oracle_scoped_text_reference_index(
-            ora_cfg,
-            set(scope_result.excluded_nodes or frozenset()),
-        )
+        excluded_nodes = set(scope_result.excluded_nodes or frozenset())
+        included_nodes = set(scope_result.included_nodes or frozenset())
+        excluded_text_index = _load_cached_source_text_index(excluded_nodes)
+        included_text_index = _load_cached_source_text_index(included_nodes)
         log.info(
             '[PERF] SAFE_TEXT round=%d: excluded_text_nodes=%d, index_candidates=%d',
             _round + 1,
-            len(set(scope_result.excluded_nodes or frozenset())),
-            pattern_index.candidate_count,
+            len(excluded_nodes),
+            reverse_pattern_index.candidate_count,
         )
         diagnostic_rows: List[Tuple[str, str, str, str]] = []
-        text_seed_rows = build_scoped_text_reference_seed_rows(
+        reverse_seed_rows = build_scoped_text_reference_seed_rows(
             scope_result,
-            scoped_text_index,
-            pattern_index=pattern_index,
+            excluded_text_index,
+            pattern_index=reverse_pattern_index,
+            diagnostic_rows=diagnostic_rows,
+        )
+        forward_pattern_index = ScopedPatternIndex(
+            build_scoped_candidate_types_by_full_from_nodes(
+                excluded_nodes,
+                include_types=SCOPED_TEXT_REFERENCE_TARGET_TYPES,
+            )
+        )
+        forward_seed_rows = build_scoped_text_dependency_seed_rows(
+            scope_result,
+            included_text_index,
+            source_objects,
+            pattern_index=forward_pattern_index,
             diagnostic_rows=diagnostic_rows,
         )
         if diagnostic_rows:
@@ -12605,6 +13406,13 @@ def apply_scoped_text_reference_fallback(
                     existing_detail_rows.append(row)
                     existing_diag.add(row)
             scope_result = scope_result._replace(detail_rows=tuple(existing_detail_rows))
+        text_seed_rows = list(reverse_seed_rows or [])
+        existing_seed_nodes = {node for node, _status, _detail in text_seed_rows}
+        for node, status, detail in (forward_seed_rows or []):
+            if node in existing_seed_nodes:
+                continue
+            text_seed_rows.append((node, status, detail))
+            existing_seed_nodes.add(node)
         if not text_seed_rows:
             return scope_result, total_added
         total_added += len(text_seed_rows)
@@ -12621,7 +13429,7 @@ def apply_scoped_text_reference_fallback(
             log.warning("[SOURCE_SCOPE] safe text fallback 在第 %d 轮无进展，停止继续扩展。", _round + 1)
             return scope_result, total_added
         new_nodes = set(next_scope.included_nodes or frozenset()) - set(scope_result.included_nodes or frozenset())
-        growth = pattern_index.extend(
+        growth = reverse_pattern_index.extend(
             build_scoped_candidate_types_by_full_from_nodes(
                 new_nodes,
                 include_types=SCOPED_TEXT_REFERENCE_TARGET_TYPES,
@@ -12632,8 +13440,8 @@ def apply_scoped_text_reference_fallback(
                 '[PERF] SAFE_TEXT round=%d index growth: new_candidates=%d, total_candidates=%d, name_buckets=%d',
                 _round + 1,
                 growth,
-                pattern_index.candidate_count,
-                pattern_index.name_bucket_count,
+                reverse_pattern_index.candidate_count,
+                reverse_pattern_index.name_bucket_count,
             )
         scope_result = next_scope
     log.warning("[SOURCE_SCOPE] safe text fallback 达到最大轮次 %d，强制退出。", max_rounds)
@@ -12726,6 +13534,7 @@ def classify_missing_objects(
             settings,
             tv_results,
             extra_results,
+            oracle_meta=oracle_meta,
         )
 
     support_state_map: Dict[Tuple[str, str], ObjectSupportReportRow] = {}
@@ -13570,6 +14379,7 @@ def classify_missing_objects_ob_source_mode(
     settings: Dict,
     tv_results: ReportResults,
     extra_results: Optional[ExtraCheckResults] = None,
+    oracle_meta: Optional[OracleMetadata] = None,
 ) -> SupportClassificationResult:
     """
     OB 源端缺失对象按 certified family 与 deferred family 分类。
@@ -13583,9 +14393,21 @@ def classify_missing_objects_ob_source_mode(
     missing_support_counts: Dict[str, Dict[str, int]] = defaultdict(
         lambda: {"supported": 0, "unsupported": 0, "blocked": 0, "risky": 0}
     )
+    extra_blocked_counts: Dict[str, int] = defaultdict(int)
+    unsupported_table_keys: Set[Tuple[str, str]] = set()
     reason_code = "OB_SOURCE_FIXUP_DEFERRED"
     reason_text = "OceanBase source mode 当前对象族尚未通过自动修补认证，已转 deferred/manual"
     action_text = "人工处理 / 等待后续 fixup 支持"
+    temp_table_keys = {
+        ((owner or "").upper(), (table or "").upper())
+        for owner, table in (getattr(oracle_meta, "temporary_tables", set()) or set())
+    }
+
+    def _is_temp_table(src_full_u: str) -> bool:
+        if "." not in (src_full_u or ""):
+            return False
+        owner_u, table_u = src_full_u.split(".", 1)
+        return (owner_u, table_u) in temp_table_keys
 
     def _build_row(
         obj_type_u: str,
@@ -13595,6 +14417,15 @@ def classify_missing_objects_ob_source_mode(
         dependency: str = "-",
         detail: str = "-",
     ) -> ObjectSupportReportRow:
+        if obj_type_u == "TABLE" and _is_temp_table(src_full_u):
+            missing_support_counts[obj_type_u]["risky"] += 1
+            return build_ob_source_temp_table_support_row(
+                obj_type_u,
+                src_full_u,
+                tgt_full_u,
+                dependency=dependency,
+                detail=detail or "TEMPORARY_TABLE",
+            )
         if is_ob_source_fixup_supported_type(obj_type_u):
             missing_support_counts[obj_type_u]["supported"] += 1
             return ObjectSupportReportRow(
@@ -13634,6 +14465,9 @@ def classify_missing_objects_ob_source_mode(
         missing_detail_rows.append(row)
         if row.support_state != SUPPORT_STATE_SUPPORTED:
             unsupported_rows.append(row)
+            if obj_type_u == "TABLE" and "." in src_full_u:
+                src_schema_u, src_table_u = src_full_u.split(".", 1)
+                unsupported_table_keys.add((src_schema_u, src_table_u))
 
     for item in (extra_results or {}).get("index_mismatched", []) or []:
         table_full = (item.table.split()[0] if item.table else "").upper()
@@ -13645,7 +14479,18 @@ def classify_missing_objects_ob_source_mode(
             if not idx_u:
                 continue
             src_full_u = f"{src_schema}.{idx_u}"
-            row = _build_row("INDEX", src_full_u, src_full_u, dependency=table_full, detail="INDEX")
+            if (src_schema, _src_table) in unsupported_table_keys:
+                row = build_ob_source_temp_table_support_row(
+                    "INDEX",
+                    src_full_u,
+                    src_full_u,
+                    dependency=table_full,
+                    detail="INDEX",
+                )
+                missing_support_counts["INDEX"]["risky"] += 1
+                extra_blocked_counts["INDEX"] += 1
+            else:
+                row = _build_row("INDEX", src_full_u, src_full_u, dependency=table_full, detail="INDEX")
             extra_missing_rows.append(row)
             if row.support_state != SUPPORT_STATE_SUPPORTED:
                 unsupported_rows.append(row)
@@ -13660,7 +14505,18 @@ def classify_missing_objects_ob_source_mode(
             if not cons_u:
                 continue
             src_full_u = f"{src_schema}.{cons_u}"
-            row = _build_row("CONSTRAINT", src_full_u, src_full_u, dependency=table_full, detail="CONSTRAINT")
+            if (src_schema, _src_table) in unsupported_table_keys:
+                row = build_ob_source_temp_table_support_row(
+                    "CONSTRAINT",
+                    src_full_u,
+                    src_full_u,
+                    dependency=table_full,
+                    detail="CONSTRAINT",
+                )
+                missing_support_counts["CONSTRAINT"]["risky"] += 1
+                extra_blocked_counts["CONSTRAINT"] += 1
+            else:
+                row = _build_row("CONSTRAINT", src_full_u, src_full_u, dependency=table_full, detail="CONSTRAINT")
             extra_missing_rows.append(row)
             if row.support_state != SUPPORT_STATE_SUPPORTED:
                 unsupported_rows.append(row)
@@ -13701,7 +14557,18 @@ def classify_missing_objects_ob_source_mode(
                 src_full_u = f"{src_owner_u}.{src_trg_u}"
                 pairs.append((src_full_u, f"{tgt_schema}.{src_trg_u}"))
         for src_full_u, tgt_full_u in pairs:
-            row = _build_row("TRIGGER", src_full_u, tgt_full_u, dependency=table_full, detail="TRIGGER")
+            if (src_schema, _src_table) in unsupported_table_keys:
+                row = build_ob_source_temp_table_support_row(
+                    "TRIGGER",
+                    src_full_u,
+                    tgt_full_u,
+                    dependency=table_full,
+                    detail="TRIGGER",
+                )
+                missing_support_counts["TRIGGER"]["risky"] += 1
+                extra_blocked_counts["TRIGGER"] += 1
+            else:
+                row = _build_row("TRIGGER", src_full_u, tgt_full_u, dependency=table_full, detail="TRIGGER")
             extra_missing_rows.append(row)
             if row.support_state != SUPPORT_STATE_SUPPORTED:
                 unsupported_rows.append(row)
@@ -13712,8 +14579,8 @@ def classify_missing_objects_ob_source_mode(
         unsupported_rows=unsupported_rows,
         extra_missing_rows=extra_missing_rows,
         missing_support_counts=dict(missing_support_counts),
-        extra_blocked_counts={},
-        unsupported_table_keys=set(),
+        extra_blocked_counts=dict(extra_blocked_counts),
+        unsupported_table_keys=unsupported_table_keys,
         unsupported_view_keys=set(),
         view_compat_map={},
         view_constraint_cleaned_rows=[],
@@ -13787,8 +14654,66 @@ def format_object_created_ts(value: Optional[datetime]) -> str:
     return value.strftime("%Y-%m-%d %H:%M:%S")
 
 
+def load_ob_source_object_created_map(
+    ob_cfg: ObConfig,
+    schemas_list: List[str],
+    source_objects: SourceObjectMap,
+    synonym_check_scope: str = "public_only",
+) -> ObjectCreatedAtMap:
+    if not source_objects:
+        return {}
+
+    tracked_types = sorted({
+        (obj_type or "").upper()
+        for types in source_objects.values()
+        for obj_type in (types or set())
+        if obj_type
+    })
+    if not tracked_types:
+        return {}
+
+    owners = {s.upper() for s in schemas_list if s}
+    scope = normalize_synonym_check_scope(synonym_check_scope)
+    if scope in {"public_only", "all"}:
+        has_public_synonym = any(
+            full_name.upper().startswith("PUBLIC.") and "SYNONYM" in {t.upper() for t in (obj_types or set())}
+            for full_name, obj_types in source_objects.items()
+        )
+        if has_public_synonym:
+            owners.add("PUBLIC")
+    if not owners:
+        return {}
+
+    types_clause = ",".join(sql_quote_literal(obj_type) for obj_type in tracked_types)
+    created_map: ObjectCreatedAtMap = {}
+    sql_tpl = f"""
+        SELECT OWNER, OBJECT_NAME, OBJECT_TYPE,
+               TO_CHAR(CREATED, 'YYYY-MM-DD HH24:MI:SS') AS CREATED_TEXT
+        FROM DBA_OBJECTS
+        WHERE OWNER IN ({{owners_in}})
+          AND OBJECT_TYPE IN ({types_clause})
+    """
+    ok, lines, err = obclient_query_by_owner_chunks(ob_cfg, sql_tpl, sorted(owners))
+    if not ok:
+        log.error("严重错误: 加载 OceanBase 源端对象 CREATED 时间失败: %s", err)
+        abort_run()
+    for line in (lines or []):
+        parts = line.split('\t')
+        if len(parts) < 4:
+            continue
+        owner_u = (parts[0] or "").strip().upper()
+        object_name_u = (parts[1] or "").strip().upper()
+        object_type_u = (parts[2] or "").strip().upper()
+        created_ts = normalize_object_created_ts(parts[3] if len(parts) > 3 else None)
+        if not owner_u or not object_name_u or not object_type_u or created_ts is None:
+            continue
+        created_map[(f"{owner_u}.{object_name_u}", object_type_u)] = created_ts
+    return created_map
+
+
 def load_source_object_created_map(
     ora_cfg: OraConfig,
+    settings: Dict,
     schemas_list: List[str],
     source_objects: SourceObjectMap,
     synonym_check_scope: str = "public_only",
@@ -13796,6 +14721,15 @@ def load_source_object_created_map(
     """
     加载源对象的 CREATED 时间，键为 (OWNER.OBJECT, OBJECT_TYPE)。
     """
+    source_db_mode = normalize_source_db_mode((settings or {}).get("source_db_mode", SOURCE_DB_MODE_ORACLE))
+    if source_db_mode == SOURCE_DB_MODE_OCEANBASE:
+        return load_ob_source_object_created_map(
+            (settings or {}).get("source_ob_cfg") or {},
+            schemas_list,
+            source_objects,
+            synonym_check_scope=synonym_check_scope,
+        )
+
     if not source_objects:
         return {}
 
@@ -14107,6 +15041,60 @@ def load_oracle_default_sequence_dependency_records(
     rows = build_default_sequence_dependency_records_from_table_columns(source_objects, table_columns)
     if rows:
         log.info('[SOURCE_SCOPE] 已从 Oracle 列默认值补充 TABLE->SEQUENCE/SYNONYM 依赖 %d 条。', len(rows))
+    return rows
+
+
+def load_ob_source_default_sequence_dependency_records(
+    ob_cfg: ObConfig,
+    source_objects: Optional[SourceObjectMap],
+) -> List[DependencyRecord]:
+    source_objects = source_objects or {}
+    table_owners = sorted({
+        full_u.split('.', 1)[0].upper()
+        for full_u, obj_types in (source_objects or {}).items()
+        if '.' in (full_u or '')
+        and 'TABLE' in {(item or '').upper() for item in (obj_types or set()) if item}
+    })
+    if not table_owners:
+        return []
+
+    table_pairs = {
+        tuple(full_u.upper().split('.', 1))
+        for full_u, obj_types in (source_objects or {}).items()
+        if '.' in (full_u or '')
+        and 'TABLE' in {(item or '').upper() for item in (obj_types or set()) if item}
+    }
+    sql_tpl = """
+        SELECT OWNER, TABLE_NAME, COLUMN_NAME,
+               REPLACE(REPLACE(REPLACE(DATA_DEFAULT, CHR(10), ' '), CHR(13), ' '), CHR(9), ' ') AS DATA_DEFAULT
+        FROM DBA_TAB_COLUMNS
+        WHERE OWNER IN ({owners_in})
+          AND DATA_DEFAULT IS NOT NULL
+    """
+    ok, lines, err = obclient_query_by_owner_chunks(ob_cfg, sql_tpl, table_owners, quiet_error=True)
+    if not ok:
+        log.warning('[SOURCE_SCOPE] 读取 OceanBase DATA_DEFAULT 序列依赖失败，将跳过 TABLE 默认值的 SEQUENCE 补边: %s', err)
+        return []
+
+    table_columns: Dict[Tuple[str, str], Dict[str, Dict]] = {}
+    for raw in (lines or []):
+        parts = raw.split('\t')
+        if len(parts) < 4:
+            continue
+        owner_u = (parts[0] or '').strip().upper()
+        table_u = (parts[1] or '').strip().upper()
+        col_u = (parts[2] or '').strip().upper()
+        if not owner_u or not table_u or not col_u:
+            continue
+        if (owner_u, table_u) not in table_pairs:
+            continue
+        table_columns.setdefault((owner_u, table_u), {})[col_u] = {
+            'data_default': parts[3],
+        }
+
+    rows = build_default_sequence_dependency_records_from_table_columns(source_objects, table_columns)
+    if rows:
+        log.info('[SOURCE_SCOPE] 已从 OceanBase 列默认值补充 TABLE->SEQUENCE/SYNONYM 依赖 %d 条。', len(rows))
     return rows
 
 
@@ -14449,6 +15437,7 @@ def get_ob_source_objects(
         include_comments=False,
         include_roles=False,
         target_table_pairs=set(),
+        enable_dba_synonym_fallback=True,
     )
     return (
         build_source_object_map_from_ob_metadata(ob_meta, enabled_types),
@@ -14577,8 +15566,61 @@ def dump_source_metadata(
         include_roles=False,
         target_table_pairs=collect_table_pairs(master_list, use_target=False) if include_comments else set(),
         include_contexts=include_contexts,
+        enable_dba_synonym_fallback=True,
     )
-    return adapt_ob_metadata_to_source_oracle_metadata(ob_meta, source_schemas)
+    oracle_meta = adapt_ob_metadata_to_source_oracle_metadata(ob_meta, source_schemas)
+    if include_privileges:
+        grant_generation_mode = normalize_grant_generation_mode(
+            settings.get('grant_generation_mode', 'full')
+        )
+        grant_priv_scope = settings.get('grant_tab_privs_scope', 'owner')
+        if grant_generation_mode == GRANT_GENERATION_MODE_STRUCTURAL:
+            grant_priv_scope = 'owner'
+        base_grantees = set(source_schemas)
+        role_privileges, role_names = load_ob_source_role_privileges(source_ob_cfg, base_grantees)
+        grantee_scope = set(base_grantees) | set(role_names) | {"PUBLIC"}
+        sys_privileges = load_ob_source_sys_privileges(source_ob_cfg, base_grantees | set(role_names))
+        object_privileges = load_ob_source_tab_privileges(
+            source_ob_cfg,
+            source_schemas,
+            grantee_scope,
+            grant_priv_scope,
+        )
+        column_privileges = load_ob_source_col_privileges(
+            source_ob_cfg,
+            source_schemas,
+            grantee_scope,
+            grant_priv_scope,
+        )
+        role_metadata = load_ob_source_roles(source_ob_cfg)
+        system_privilege_map = load_ob_source_system_privilege_map(source_ob_cfg)
+        table_privilege_map = load_ob_source_table_privilege_map(source_ob_cfg)
+        privilege_family_counts = build_ob_source_privilege_family_counts(
+            object_privileges,
+            column_privileges,
+            sys_privileges,
+            role_privileges,
+        )
+        log.info(
+            "OceanBase 源端权限元数据加载完成：对象权限=%d, 列级权限=%d, 系统权限=%d, 角色授权=%d, 角色数=%d, scope=%s",
+            len(object_privileges),
+            len(column_privileges),
+            len(sys_privileges),
+            len(role_privileges),
+            len(role_metadata),
+            grant_priv_scope,
+        )
+        oracle_meta = oracle_meta._replace(
+            object_privileges=list(object_privileges),
+            column_privileges=list(column_privileges),
+            sys_privileges=list(sys_privileges),
+            role_privileges=list(role_privileges),
+            role_metadata=dict(role_metadata),
+            system_privilege_map=set(system_privilege_map),
+            table_privilege_map=set(table_privilege_map),
+            privilege_family_counts=tuple(privilege_family_counts),
+        )
+    return oracle_meta
 
 
 def load_source_dependencies(
@@ -14645,7 +15687,7 @@ def load_ob_source_synonym_metadata(
         name = (parts[1] or "").strip().upper()
         table_owner = normalize_public_owner(parts[2])
         table_name = (parts[3] or "").strip().upper()
-        db_link = (parts[4] or "").strip().upper() if len(parts) > 4 and parts[4] else None
+        db_link = normalize_obclient_nullable_text(parts[4] if len(parts) > 4 else None, upper=True)
         if not owner or not name or not table_name:
             continue
         result[(owner, name)] = SynonymMeta(
@@ -14680,7 +15722,7 @@ def load_ob_source_synonym_metadata(
                     name = (parts[1] or "").strip().upper()
                     table_owner = normalize_public_owner(parts[2])
                     table_name = (parts[3] or "").strip().upper()
-                    db_link = (parts[4] or "").strip().upper() if len(parts) > 4 and parts[4] else None
+                    db_link = normalize_obclient_nullable_text(parts[4] if len(parts) > 4 else None, upper=True)
                     if not owner or not name or not table_name:
                         continue
                     result[(owner, name)] = SynonymMeta(
@@ -14710,7 +15752,7 @@ def load_ob_source_synonym_metadata(
                     name = (parts[1] or "").strip().upper()
                     table_owner = normalize_public_owner(parts[2])
                     table_name = (parts[3] or "").strip().upper()
-                    db_link = (parts[4] or "").strip().upper() if len(parts) > 4 and parts[4] else None
+                    db_link = normalize_obclient_nullable_text(parts[4] if len(parts) > 4 else None, upper=True)
                     if not owner or not name or not table_name:
                         continue
                     result[(owner, name)] = SynonymMeta(
@@ -15926,6 +16968,32 @@ def build_view_callable_dep_map(
         source_dependencies,
         VIEW_CALLABLE_DEP_TYPES,
     )
+
+
+def build_view_dependency_map_from_scope_detail_rows(
+    detail_rows: Optional[Sequence[Tuple[str, str, str, str]]],
+) -> Dict[Tuple[str, str], Set[str]]:
+    """
+    从 remap_root_closure 的 text heuristic 明细回灌 VIEW 依赖。
+    主要用于补足 DBA_DEPENDENCIES 看不到的 VIEW -> SYNONYM/VIEW 引用。
+    """
+    view_map: Dict[Tuple[str, str], Set[str]] = defaultdict(set)
+    for status, obj_type, full_u, detail in (detail_rows or ()):
+        if (status or "").upper() != "TEXT_DEPENDENCY_HEURISTIC":
+            continue
+        detail_u = (detail or "").upper()
+        if not detail_u.startswith("REFERENCED_BY:VIEW:"):
+            continue
+        ref_view_full = detail_u.split("REFERENCED_BY:VIEW:", 1)[1].strip().upper()
+        dep_full_u = (full_u or "").upper()
+        if "." not in ref_view_full or "." not in dep_full_u:
+            continue
+        ref_owner_u, ref_name_u = ref_view_full.split(".", 1)
+        dep_type_u = (obj_type or "").upper()
+        if dep_type_u not in REWRITE_ELIGIBLE_DEP_TYPES:
+            continue
+        view_map[(ref_owner_u, ref_name_u)].add(dep_full_u)
+    return dict(view_map)
 
 
 def collect_ob_schema_names(ob_meta: Optional["ObMetadata"]) -> Set[str]:
@@ -17611,6 +18679,19 @@ def build_source_scope_diagnostics(scope_result: ScopedSourceScopeResult) -> Lis
                 sample=sample or "-",
             )
         )
+    scheduler_ambiguous = [
+        (obj_type, full_name, detail)
+        for status, obj_type, full_name, detail in (scope_result.detail_rows or ())
+        if (status or "").upper() in {"SCHEDULER_CREATE_AMBIGUOUS", "SCHEDULER_CREATE_TARGET_UNRESOLVED"}
+    ]
+    if scheduler_ambiguous:
+        sample = ", ".join(f"{full}:{detail}" for _obj_type, full, detail in scheduler_ambiguous[:5])
+        diagnostics.append(
+            "scheduler create unresolved={count}; sample={sample}".format(
+                count=len(scheduler_ambiguous),
+                sample=sample or "-",
+            )
+        )
     return diagnostics
 
 
@@ -17646,14 +18727,24 @@ def build_scheduler_scope_diagnostics(
         "SCHEDULE" in {(item or "").upper() for item in (obj_types or set()) if item}
         for obj_types in source_objects.values()
     )
-    if not has_schedule:
+    has_job = any(
+        "JOB" in {(item or "").upper() for item in (obj_types or set()) if item}
+        for obj_types in source_objects.values()
+    )
+    if not has_schedule and not has_job:
         return []
     diagnostics: List[str] = []
-    diagnostics.append(
-        "SCHEDULE 对象当前不做结构化补边；REPEAT_INTERVAL 不按数据库对象依赖解析。mode={mode}".format(
-            mode=normalize_remap_scope_text_fallback_mode(remap_scope_text_fallback_mode)
+    if has_schedule:
+        diagnostics.append(
+            "SCHEDULE 对象当前不做结构化补边；REPEAT_INTERVAL 不按数据库对象依赖解析。mode={mode}".format(
+                mode=normalize_remap_scope_text_fallback_mode(remap_scope_text_fallback_mode)
+            )
         )
-    )
+    if normalize_remap_scope_text_fallback_mode(remap_scope_text_fallback_mode) != "safe":
+        diagnostics.append(
+            "DBMS_SCHEDULER.CREATE_JOB/CREATE_SCHEDULE 的源码静态补盲需 remap_scope_text_fallback_mode=safe；"
+            "当前不会从程序源码自动纳入新建 JOB/SCHEDULE。"
+        )
     return diagnostics
 
 
@@ -18259,7 +19350,7 @@ def export_managed_target_scope_detail(
 
 
 def collect_explicit_root_fulls(scope_result: Optional[ScopedSourceScopeResult]) -> Set[str]:
-    if not scope_result or (scope_result.mode or "").lower() != "remap_root_closure":
+    if not scope_result or normalize_source_object_scope_mode(scope_result.mode) not in {"explicit_roots", "remap_root_closure"}:
         return set()
     return {
         (full or "").upper()
@@ -19426,6 +20517,7 @@ def dump_ob_metadata(
     include_roles: bool = False,
     target_table_pairs: Optional[Set[Tuple[str, str]]] = None,
     include_contexts: bool = False,
+    enable_dba_synonym_fallback: bool = False,
 ) -> ObMetadata:
     """
     一次性从 OceanBase dump 所有需要的元数据，返回 ObMetadata。
@@ -19457,6 +20549,8 @@ def dump_ob_metadata(
             temporary_tables=frozenset(),
             enabled_notnull_check_groups=MappingProxyType({}),
             contexts=MappingProxyType({}),
+            context_inventory_error="",
+            context_inventory_health=CONTEXT_INVENTORY_HEALTH_HEALTHY,
         )
 
     synonym_scope = normalize_synonym_check_scope(synonym_check_scope)
@@ -19587,7 +20681,7 @@ def dump_ob_metadata(
     )
 
     # 部分 OB 版本/兼容模式下，同义词不会稳定出现在 DBA_OBJECTS，需要补查 DBA_SYNONYMS。
-    if 'SYNONYM' in object_types_filter:
+    if enable_dba_synonym_fallback and 'SYNONYM' in object_types_filter:
         synonym_meta = load_ob_source_synonym_metadata(
             ob_cfg,
             owners_in_list,
@@ -20484,6 +21578,8 @@ def dump_ob_metadata(
 
     roles: Set[str] = set()
     contexts: Dict[str, ContextMetadata] = {}
+    context_inventory_error = ""
+    context_inventory_health = CONTEXT_INVENTORY_HEALTH_HEALTHY
     # --- 9. DBA_ROLES ---
     if include_roles:
         sql = "SELECT ROLE FROM DBA_ROLES"
@@ -20497,7 +21593,8 @@ def dump_ob_metadata(
                     roles.add(role)
 
     if include_contexts:
-        contexts, ctx_err = load_ob_context_inventory(ob_cfg, set(owners_in_list))
+        contexts, ctx_err, context_inventory_health = load_ob_context_inventory(ob_cfg, set(owners_in_list))
+        context_inventory_error = str(ctx_err or "")
         if ctx_err:
             log.warning("读取 OB DBA_CONTEXT 失败，context compare/fixup 将保守降级: %s", ctx_err)
 
@@ -20530,6 +21627,8 @@ def dump_ob_metadata(
         enabled_notnull_check_columns=enabled_notnull_check_columns,
         enabled_notnull_check_groups=enabled_notnull_check_groups,
         contexts=contexts,
+        context_inventory_error=context_inventory_error,
+        context_inventory_health=context_inventory_health,
     )
     ob_table_count = len(ob_meta.tab_columns)
     ob_column_count = sum(len(cols) for cols in ob_meta.tab_columns.values())
@@ -20608,6 +21707,303 @@ def load_ob_users(ob_cfg: ObConfig) -> Optional[Set[str]]:
     if not users:
         log.warning("OB 端用户列表为空，授权 grantee 用户过滤可能不完整。")
     return users
+
+
+def _build_ob_sql_literal_list(values: Sequence[str]) -> str:
+    safe_vals = [str(v).replace("'", "''") for v in values if str(v).strip()]
+    return ",".join(f"'{v}'" for v in safe_vals)
+
+
+def load_ob_source_roles(ob_cfg: ObConfig) -> Dict[str, OracleRoleInfo]:
+    roles: Dict[str, OracleRoleInfo] = {}
+    sql = "SELECT ROLE FROM DBA_ROLES"
+    ok, out, err = obclient_run_sql(ob_cfg, sql)
+    if not ok:
+        log.warning("读取 OceanBase 源端 DBA_ROLES 失败，角色 DDL 元数据将保守降级: %s", err)
+        return {}
+    for line in (out or "").splitlines():
+        role_u = (line or "").strip().upper()
+        if not role_u:
+            continue
+        roles[role_u] = OracleRoleInfo(
+            role=role_u,
+            authentication_type="NONE",
+            password_required=False,
+            oracle_maintained=False,
+        )
+    return roles
+
+
+def load_ob_source_system_privilege_map(ob_cfg: ObConfig) -> Set[str]:
+    return load_ob_supported_sys_privs(ob_cfg)
+
+
+def load_ob_source_table_privilege_map(ob_cfg: ObConfig) -> Set[str]:
+    privs: Set[str] = set()
+    sql = "SELECT DISTINCT PRIVILEGE FROM DBA_TAB_PRIVS"
+    ok, out, err = obclient_run_sql(ob_cfg, sql)
+    if not ok:
+        log.warning("读取 OceanBase 源端 DBA_TAB_PRIVS 权限全集失败: %s", err)
+        return set()
+    for line in (out or "").splitlines():
+        privilege = (line or "").strip().upper()
+        if privilege:
+            privs.add(privilege)
+    return privs
+
+
+def load_ob_source_role_privileges(
+    ob_cfg: ObConfig,
+    grantees: Set[str],
+) -> Tuple[List[OracleRolePrivilege], Set[str]]:
+    role_grants: List[OracleRolePrivilege] = []
+    discovered_roles: Set[str] = set()
+    seen_rows: Set[Tuple[str, str, bool]] = set()
+    pending: Set[str] = {(item or "").upper() for item in (grantees or set()) if item}
+    scanned: Set[str] = set()
+
+    while pending:
+        batch = sorted(pending - scanned)
+        if not batch:
+            break
+        scanned.update(batch)
+        for chunk in chunk_list(batch, 900):
+            grantee_list = _build_ob_sql_literal_list(chunk)
+            if not grantee_list:
+                continue
+            sql = textwrap.dedent(f"""
+                SELECT GRANTEE, GRANTED_ROLE, ADMIN_OPTION
+                FROM DBA_ROLE_PRIVS
+                WHERE GRANTEE IN ({grantee_list})
+            """).strip()
+            ok, out, err = obclient_run_sql(ob_cfg, sql)
+            if not ok:
+                log.warning("读取 OceanBase 源端 DBA_ROLE_PRIVS 失败: %s", err)
+                return role_grants, discovered_roles
+            for line in (out or "").splitlines():
+                parts = line.split('\t')
+                if len(parts) < 3:
+                    continue
+                grantee_u = (parts[0] or "").strip().upper()
+                role_u = (parts[1] or "").strip().upper()
+                admin_option = (parts[2] or "").strip().upper() == "YES"
+                if not grantee_u or not role_u:
+                    continue
+                row_key = (grantee_u, role_u, admin_option)
+                if row_key not in seen_rows:
+                    role_grants.append(OracleRolePrivilege(
+                        grantee=grantee_u,
+                        role=role_u,
+                        admin_option=admin_option,
+                    ))
+                    seen_rows.add(row_key)
+                if role_u not in discovered_roles:
+                    discovered_roles.add(role_u)
+                if role_u not in scanned:
+                    pending.add(role_u)
+
+    return role_grants, discovered_roles
+
+
+def load_ob_source_sys_privileges(
+    ob_cfg: ObConfig,
+    grantees: Set[str],
+) -> List[OracleSysPrivilege]:
+    sys_privs: List[OracleSysPrivilege] = []
+    seen_rows: Set[Tuple[str, str, bool]] = set()
+    for chunk in chunk_list(sorted({(item or "").upper() for item in (grantees or set()) if item}), 900):
+        grantee_list = _build_ob_sql_literal_list(chunk)
+        if not grantee_list:
+            continue
+        sql = textwrap.dedent(f"""
+            SELECT GRANTEE, PRIVILEGE, ADMIN_OPTION
+            FROM DBA_SYS_PRIVS
+            WHERE GRANTEE IN ({grantee_list})
+        """).strip()
+        ok, out, err = obclient_run_sql(ob_cfg, sql)
+        if not ok:
+            log.warning("读取 OceanBase 源端 DBA_SYS_PRIVS 失败: %s", err)
+            return []
+        for line in (out or "").splitlines():
+            parts = line.split('\t')
+            if len(parts) < 3:
+                continue
+            grantee_u = (parts[0] or "").strip().upper()
+            privilege_u = (parts[1] or "").strip().upper()
+            admin_option = (parts[2] or "").strip().upper() == "YES"
+            if not grantee_u or not privilege_u:
+                continue
+            row_key = (grantee_u, privilege_u, admin_option)
+            if row_key in seen_rows:
+                continue
+            sys_privs.append(OracleSysPrivilege(
+                grantee=grantee_u,
+                privilege=privilege_u,
+                admin_option=admin_option,
+            ))
+            seen_rows.add(row_key)
+    return sys_privs
+
+
+def load_ob_source_tab_privileges(
+    ob_cfg: ObConfig,
+    owners: Set[str],
+    grantees: Set[str],
+    scope: str = "owner",
+) -> List[OracleObjectPrivilege]:
+    def _load_for(column: str, values: Set[str]) -> List[OracleObjectPrivilege]:
+        results: List[OracleObjectPrivilege] = []
+        if not values:
+            return results
+        for chunk in chunk_list(sorted({(item or "").upper() for item in values if item}), 900):
+            value_list = _build_ob_sql_literal_list(chunk)
+            if not value_list:
+                continue
+            sql = textwrap.dedent(f"""
+                SELECT GRANTEE, OWNER, TABLE_NAME, PRIVILEGE, GRANTABLE
+                FROM DBA_TAB_PRIVS
+                WHERE {column} IN ({value_list})
+            """).strip()
+            ok, out, err = obclient_run_sql(ob_cfg, sql)
+            if not ok:
+                log.warning("读取 OceanBase 源端 DBA_TAB_PRIVS 失败(%s): %s", column, err)
+                return []
+            for line in (out or "").splitlines():
+                parts = line.split('\t')
+                if len(parts) < 5:
+                    continue
+                grantee_u = (parts[0] or "").strip().upper()
+                owner_u = (parts[1] or "").strip().upper()
+                object_name_u = (parts[2] or "").strip().upper()
+                privilege_u = (parts[3] or "").strip().upper()
+                grantable = (parts[4] or "").strip().upper() == "YES"
+                if not grantee_u or not owner_u or not object_name_u or not privilege_u:
+                    continue
+                results.append(OracleObjectPrivilege(
+                    grantee=grantee_u,
+                    owner=owner_u,
+                    object_name=object_name_u,
+                    object_type="",
+                    privilege=privilege_u,
+                    grantable=grantable,
+                ))
+        return results
+
+    scope_u = (scope or "owner").strip().lower()
+    if scope_u not in {"owner", "owner_or_grantee"}:
+        log.warning("未知 grant_tab_privs_scope=%s，OB 源端对象权限回退为 owner。", scope)
+        scope_u = "owner"
+
+    results: List[OracleObjectPrivilege] = []
+    results.extend(_load_for("OWNER", owners))
+    if scope_u == "owner_or_grantee":
+        results.extend(_load_for("GRANTEE", grantees))
+
+    deduped: Dict[Tuple[str, str, str, str, bool], OracleObjectPrivilege] = {}
+    for item in results:
+        key = (
+            item.grantee.upper(),
+            item.owner.upper(),
+            item.object_name.upper(),
+            item.privilege.upper(),
+            bool(item.grantable),
+        )
+        deduped.setdefault(key, item)
+    return list(deduped.values())
+
+
+def load_ob_source_col_privileges(
+    ob_cfg: ObConfig,
+    owners: Set[str],
+    grantees: Set[str],
+    scope: str = "owner",
+) -> List[OracleColumnPrivilege]:
+    def _load_for(column: str, values: Set[str]) -> List[OracleColumnPrivilege]:
+        results: List[OracleColumnPrivilege] = []
+        if not values:
+            return results
+        for chunk in chunk_list(sorted({(item or "").upper() for item in values if item}), 900):
+            value_list = _build_ob_sql_literal_list(chunk)
+            if not value_list:
+                continue
+            sql = textwrap.dedent(f"""
+                SELECT GRANTEE, OWNER, TABLE_NAME, COLUMN_NAME, PRIVILEGE, GRANTABLE
+                FROM DBA_COL_PRIVS
+                WHERE {column} IN ({value_list})
+            """).strip()
+            ok, out, err = obclient_run_sql(ob_cfg, sql)
+            if not ok:
+                log.warning("读取 OceanBase 源端 DBA_COL_PRIVS 失败(%s): %s", column, err)
+                return []
+            for line in (out or "").splitlines():
+                parts = line.split('\t')
+                if len(parts) < 6:
+                    continue
+                grantee_u = (parts[0] or "").strip().upper()
+                owner_u = (parts[1] or "").strip().upper()
+                object_name_u = (parts[2] or "").strip().upper()
+                column_name_u = (parts[3] or "").strip().upper()
+                privilege_u = (parts[4] or "").strip().upper()
+                grantable = (parts[5] or "").strip().upper() == "YES"
+                if not grantee_u or not owner_u or not object_name_u or not column_name_u or not privilege_u:
+                    continue
+                results.append(OracleColumnPrivilege(
+                    grantee=grantee_u,
+                    owner=owner_u,
+                    object_name=object_name_u,
+                    column_name=column_name_u,
+                    privilege=privilege_u,
+                    grantable=grantable,
+                ))
+        return results
+
+    scope_u = (scope or "owner").strip().lower()
+    if scope_u not in {"owner", "owner_or_grantee"}:
+        log.warning("未知 grant_tab_privs_scope=%s，OB 源端列级权限回退为 owner。", scope)
+        scope_u = "owner"
+
+    results: List[OracleColumnPrivilege] = []
+    results.extend(_load_for("OWNER", owners))
+    if scope_u == "owner_or_grantee":
+        results.extend(_load_for("GRANTEE", grantees))
+
+    deduped: Dict[Tuple[str, str, str, str, str, bool], OracleColumnPrivilege] = {}
+    for item in results:
+        key = (
+            item.grantee.upper(),
+            item.owner.upper(),
+            item.object_name.upper(),
+            item.column_name.upper(),
+            item.privilege.upper(),
+            bool(item.grantable),
+        )
+        deduped.setdefault(key, item)
+    return list(deduped.values())
+
+
+def build_ob_source_privilege_family_counts(
+    object_privileges: Sequence[OracleObjectPrivilege],
+    column_privileges: Sequence[OracleColumnPrivilege],
+    sys_privileges: Sequence[OracleSysPrivilege],
+    role_privileges: Sequence[OracleRolePrivilege],
+) -> Tuple[OraclePrivilegeFamilyCount, ...]:
+    rows: List[OraclePrivilegeFamilyCount] = []
+    family_specs = (
+        ("OBJECT_PRIV", "DBA_TAB_PRIVS", len(object_privileges)),
+        ("COLUMN_PRIV", "DBA_COL_PRIVS", len(column_privileges)),
+        ("SYSTEM_PRIV", "DBA_SYS_PRIVS", len(sys_privileges)),
+        ("ROLE_PRIV", "DBA_ROLE_PRIVS", len(role_privileges)),
+    )
+    for family_id, source_view, count in family_specs:
+        if int(count or 0) <= 0:
+            continue
+        rows.append(OraclePrivilegeFamilyCount(
+            family_id=family_id,
+            source_view=source_view,
+            source_row_count=int(count or 0),
+            migration_mode="RUNNABLE",
+        ))
+    return tuple(rows)
 
 
 def build_grant_capability_library(
@@ -22829,6 +24225,8 @@ def dump_oracle_metadata(
     temporary_tables: Set[Tuple[str, str]] = set()
     nested_table_storage_tables: Dict[Tuple[str, str], NestedTableStorageInfo] = {}
     contexts: Dict[str, ContextMetadata] = {}
+    context_inventory_error = ""
+    context_inventory_health = CONTEXT_INVENTORY_HEALTH_HEALTHY
     invisible_column_supported = False
     identity_column_supported = False
     default_on_null_supported = False
@@ -23676,7 +25074,8 @@ def dump_oracle_metadata(
                             comments_complete = False
 
                 if include_contexts:
-                    contexts, ctx_err = load_oracle_context_inventory(ora_cfg, source_schema_set)
+                    contexts, ctx_err, context_inventory_health = load_oracle_context_inventory(ora_cfg, source_schema_set)
+                    context_inventory_error = str(ctx_err or "")
                     if ctx_err:
                         log.warning("读取 Oracle DBA_CONTEXT 失败，context compare/fixup 将保守降级: %s", ctx_err)
 
@@ -24097,6 +25496,8 @@ def dump_oracle_metadata(
         identity_options=identity_options,
         nested_table_storage_tables=nested_table_storage_tables,
         contexts=contexts,
+        context_inventory_error=context_inventory_error,
+        context_inventory_health=context_inventory_health,
     )
 
 
@@ -28185,9 +29586,10 @@ def check_primary_objects(
                             )
                         )
 
-                source_novalidate_meta = src_notnull_novalidate_cols.get(col_name.upper())
-                source_enabled_notnull_meta = src_enabled_notnull_cols.get(col_name.upper())
-                target_notnull_meta = tgt_enabled_notnull_cols.get(col_name.upper())
+                col_semantic_key = normalize_semantic_identifier_name(col_name)
+                source_novalidate_meta = src_notnull_novalidate_cols.get(col_semantic_key)
+                source_enabled_notnull_meta = src_enabled_notnull_cols.get(col_semantic_key)
+                target_notnull_meta = tgt_enabled_notnull_cols.get(col_semantic_key)
                 target_has_notnull_check = target_notnull_meta is not None
                 target_has_physical_notnull = normalize_nullable_flag(tgt_info.get("nullable")) == "N"
                 target_has_notnull_semantic = target_has_notnull_check or target_has_physical_notnull
@@ -29878,7 +31280,7 @@ def compare_constraints_for_table(
                 matched_expr_keys_any.add(expr_key)
                 used.add(matched_name)
                 continue
-            src_notnull_col = normalize_identifier_name(_extract_notnull_column(raw_expr))
+            src_notnull_col = normalize_semantic_identifier_name(_extract_notnull_column(raw_expr))
             if src_notnull_col and src_notnull_col in tgt_enabled_notnull_groups:
                 continue
             # 源端同语义重复 CHECK：目标端已有同语义命中时，不再继续标记 missing。
@@ -29899,7 +31301,7 @@ def compare_constraints_for_table(
             if expr_key in src_expr_keys and expr_key not in expr_keys_with_name_match:
                 check_suppressed_target_dup_count += 1
                 continue
-            extra_notnull_col = _extract_notnull_column(raw_expr)
+            extra_notnull_col = normalize_semantic_identifier_name(_extract_notnull_column(raw_expr))
             if extra_notnull_col and extra_notnull_col in src_system_notnull_novalidate_cols:
                 tgt_meta = tgt_cons.get(name) or {}
                 if normalize_constraint_enabled_status(tgt_meta.get("status")) == "ENABLED":
@@ -30808,6 +32210,12 @@ def check_comments(
         results["skipped_reason"] = "未成功加载 OceanBase 注释元数据，已跳过注释比对。"
         return results
 
+    ob_tables = {
+        (name or "").upper()
+        for name in (ob_meta.objects_by_type.get("TABLE", set()) or set())
+        if name
+    }
+
     for src_name, tgt_name, obj_type in master_list:
         if obj_type.upper() != 'TABLE':
             continue
@@ -30825,11 +32233,6 @@ def check_comments(
                 (transformed_blacklist_columns_by_table or {}).get(src_key, set())
             )
             if normalize_identifier_name(col)
-        }
-        ob_tables = {
-            (name or "").upper()
-            for name in (ob_meta.objects_by_type.get("TABLE", set()) or set())
-            if name
         }
         full_tgt = f"{tgt_key[0]}.{tgt_key[1]}"
         if full_tgt not in ob_tables:
@@ -31128,6 +32531,8 @@ def check_object_usability(
         return None
 
     check_source = parse_bool_flag(settings.get("check_source_usability", "true"), True)
+    source_db_mode = normalize_source_db_mode(settings.get("source_db_mode", SOURCE_DB_MODE_ORACLE))
+    source_ob_cfg = settings.get("source_ob_cfg") or {}
     try:
         timeout_sec = int(settings.get("usability_check_timeout", "10"))
     except (TypeError, ValueError):
@@ -31336,7 +32741,7 @@ def check_object_usability(
             oracle_local.conn = conn
         return conn
 
-    def _oracle_check(full_name: str, obj_type: str) -> Tuple[Optional[bool], str, int, bool]:
+    def _source_oracle_check(full_name: str, obj_type: str) -> Tuple[Optional[bool], str, int, bool]:
         sql = _build_usability_query(full_name, obj_type)
         if not sql:
             return None, "INVALID_NAME", 0, False
@@ -31352,6 +32757,19 @@ def check_object_usability(
             msg = normalize_error_text(str(exc))
             timeout_hit = any(token in msg.upper() for token in ("DPY-4011", "ORA-01013", "TIMEOUT"))
             return False, msg, int((time.perf_counter() - start) * 1000), timeout_hit
+
+    def _source_ob_check(full_name: str, obj_type: str) -> Tuple[Optional[bool], str, int, bool]:
+        sql = _build_usability_query(full_name, obj_type)
+        if not sql:
+            return None, "INVALID_NAME", 0, False
+        start = time.perf_counter()
+        ok, _out, err = obclient_run_sql(source_ob_cfg, sql, timeout=timeout_sec)
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        if ok:
+            return True, "", duration_ms, False
+        err_msg = normalize_error_text(err)
+        timeout_hit = "TIMEOUT" in err_msg.upper() or "TIMEOUTEXPIRED" in err_msg.upper()
+        return False, err_msg, duration_ms, timeout_hit
 
     def _ob_check(full_name: str, obj_type: str) -> Tuple[Optional[bool], str, int, bool]:
         sql = _build_usability_query(full_name, obj_type)
@@ -31399,7 +32817,10 @@ def check_object_usability(
         src_ms = 0
         src_timeout = False
         if check_source:
-            src_usable, src_err, src_ms, src_timeout = _oracle_check(src_full, obj_type_u)
+            if source_db_mode == SOURCE_DB_MODE_OCEANBASE:
+                src_usable, src_err, src_ms, src_timeout = _source_ob_check(src_full, obj_type_u)
+            else:
+                src_usable, src_err, src_ms, src_timeout = _source_oracle_check(src_full, obj_type_u)
 
         timeout_hit = tgt_timeout or src_timeout
         status = classify_usability_status(check_source, src_usable, tgt_usable, timeout_hit)
@@ -31883,6 +33304,8 @@ def check_table_data_presence(
         return None
     if "TABLE" not in enabled_primary_types:
         return None
+    source_db_mode = normalize_source_db_mode(settings.get("source_db_mode", SOURCE_DB_MODE_ORACLE))
+    source_ob_cfg = settings.get("source_ob_cfg") or {}
 
     missing_target_tables: Set[str] = {
         (tgt_full or "").upper()
@@ -31982,11 +33405,18 @@ def check_table_data_presence(
         source_keys = sorted({(src_schema, src_table) for src_schema, src_table, _tgt_schema, _tgt_table in candidates})
         target_keys = sorted({(tgt_schema, tgt_table) for _src_schema, _src_table, tgt_schema, tgt_table in candidates})
 
-        source_stats, source_stats_err = _load_oracle_table_num_rows_from_stats(
-            ora_cfg,
-            source_keys,
-            oracle_timeout_ms
-        )
+        if source_db_mode == SOURCE_DB_MODE_OCEANBASE:
+            source_stats, source_stats_err = _load_ob_table_num_rows_from_stats(
+                source_ob_cfg,
+                source_keys,
+                ob_timeout,
+            )
+        else:
+            source_stats, source_stats_err = _load_oracle_table_num_rows_from_stats(
+                ora_cfg,
+                source_keys,
+                oracle_timeout_ms
+            )
         target_stats, target_stats_err = _load_ob_table_num_rows_from_stats(
             ob_cfg,
             target_keys,
@@ -32017,17 +33447,30 @@ def check_table_data_presence(
             source_zero_probe: Dict[Tuple[str, str], Tuple[Optional[bool], str, int]] = {}
             target_zero_probe: Dict[Tuple[str, str], Tuple[Optional[bool], str, int]] = {}
             if source_probe_keys:
-                log.info(
-                    "[TABLE_PRESENCE] SOURCE 零行/缺统二次探测开始：tables=%d, workers=%d",
-                    len(source_probe_keys),
-                    source_zero_workers
-                )
-                source_zero_probe = _probe_oracle_table_has_rows_batch(
-                    ora_cfg,
-                    source_probe_keys,
-                    oracle_timeout_ms,
-                    source_zero_workers
-                )
+                if source_db_mode == SOURCE_DB_MODE_OCEANBASE:
+                    log.info(
+                        "[TABLE_PRESENCE] SOURCE 零行/缺统二次探测开始：tables=%d, chunk_size=%d",
+                        len(source_probe_keys),
+                        chunk_size
+                    )
+                    source_zero_probe = _probe_ob_table_has_rows_batch(
+                        source_ob_cfg,
+                        source_probe_keys,
+                        chunk_size,
+                        ob_timeout,
+                    )
+                else:
+                    log.info(
+                        "[TABLE_PRESENCE] SOURCE 零行/缺统二次探测开始：tables=%d, workers=%d",
+                        len(source_probe_keys),
+                        source_zero_workers
+                    )
+                    source_zero_probe = _probe_oracle_table_has_rows_batch(
+                        ora_cfg,
+                        source_probe_keys,
+                        oracle_timeout_ms,
+                        source_zero_workers
+                    )
                 source_unknown = sum(1 for v in source_zero_probe.values() if v[0] is None)
                 log.info(
                     "[TABLE_PRESENCE] SOURCE 零行/缺统二次探测完成：tables=%d, unknown=%d",
@@ -32184,42 +33627,58 @@ def check_table_data_presence(
     )
     start_perf = time.perf_counter()
     source_probe: Dict[Tuple[str, str], Tuple[Optional[bool], str, int]] = {}
-    source_conn: Optional[oracledb.Connection] = None
-    try:
-        source_conn = oracledb.connect(
-            user=ora_cfg["user"],
-            password=ora_cfg["password"],
-            dsn=ora_cfg["dsn"]
+    if source_db_mode == SOURCE_DB_MODE_OCEANBASE:
+        source_keys: List[Tuple[str, str]] = []
+        seen_source: Set[Tuple[str, str]] = set()
+        for src_schema, src_table, _tgt_schema, _tgt_table in candidates:
+            source_key = (src_schema, src_table)
+            if source_key in seen_source:
+                continue
+            seen_source.add(source_key)
+            source_keys.append(source_key)
+        source_probe = _probe_ob_table_has_rows_batch(
+            source_ob_cfg,
+            source_keys,
+            chunk_size,
+            ob_timeout,
         )
-        for src_schema, src_table, _tgt_schema, _tgt_table in candidates:
-            sql = f"SELECT 1 FROM {quote_qualified_parts(src_schema, src_table)} WHERE ROWNUM=1"
-            begin = time.perf_counter()
-            src_flag: Optional[bool] = None
-            src_err = ""
-            try:
-                with source_conn.cursor() as cursor:
-                    cursor.call_timeout = oracle_timeout_ms
-                    cursor.execute(sql)
-                    src_flag = cursor.fetchone() is not None
-            except Exception as exc:
-                src_flag = None
-                src_err = normalize_error_text(str(exc))
-            source_probe[(src_schema, src_table)] = (
-                src_flag,
-                src_err,
-                int((time.perf_counter() - begin) * 1000)
+    else:
+        source_conn: Optional[oracledb.Connection] = None
+        try:
+            source_conn = oracledb.connect(
+                user=ora_cfg["user"],
+                password=ora_cfg["password"],
+                dsn=ora_cfg["dsn"]
             )
-    except Exception as exc:
-        src_connect_err = normalize_error_text(str(exc))
-        log.warning("[TABLE_PRESENCE] Oracle 探测连接失败：%s", src_connect_err)
-        for src_schema, src_table, _tgt_schema, _tgt_table in candidates:
-            source_probe[(src_schema, src_table)] = (None, src_connect_err, 0)
-    finally:
-        if source_conn:
-            try:
-                source_conn.close()
-            except Exception:
-                pass
+            for src_schema, src_table, _tgt_schema, _tgt_table in candidates:
+                sql = f"SELECT 1 FROM {quote_qualified_parts(src_schema, src_table)} WHERE ROWNUM=1"
+                begin = time.perf_counter()
+                src_flag: Optional[bool] = None
+                src_err = ""
+                try:
+                    with source_conn.cursor() as cursor:
+                        cursor.call_timeout = oracle_timeout_ms
+                        cursor.execute(sql)
+                        src_flag = cursor.fetchone() is not None
+                except Exception as exc:
+                    src_flag = None
+                    src_err = normalize_error_text(str(exc))
+                source_probe[(src_schema, src_table)] = (
+                    src_flag,
+                    src_err,
+                    int((time.perf_counter() - begin) * 1000)
+                )
+        except Exception as exc:
+            src_connect_err = normalize_error_text(str(exc))
+            log.warning("[TABLE_PRESENCE] Oracle 探测连接失败：%s", src_connect_err)
+            for src_schema, src_table, _tgt_schema, _tgt_table in candidates:
+                source_probe[(src_schema, src_table)] = (None, src_connect_err, 0)
+        finally:
+            if source_conn:
+                try:
+                    source_conn.close()
+                except Exception:
+                    pass
 
     target_keys: List[Tuple[str, str]] = []
     seen_target: Set[Tuple[str, str]] = set()
@@ -33996,7 +35455,22 @@ def clean_view_ddl_for_oceanbase_with_audit(
     if ob_version:
         # 如果版本 >= 4.2.5.7，可保留 WITH CHECK OPTION
         remove_check_option = compare_version(ob_version, "4.2.5.7") < 0
-    if remove_check_option:
+    masked_view = mask_sql_for_scan(cleaned_ddl)
+    join_view_check_option = bool(
+        re.search(r'\bWITH\s+CHECK\s+OPTION\b', masked_view, flags=re.IGNORECASE)
+        and re.search(r'\bJOIN\b', masked_view, flags=re.IGNORECASE)
+    )
+    if join_view_check_option:
+        patterns_to_remove.append(
+            (
+                "clean_view_check_option_join_view_clause",
+                r'\s+WITH\s+CHECK\s+OPTION',
+                DDL_CLEAN_CATEGORY_SYNTAX_COMPAT,
+                DDL_CLEAN_EVIDENCE_VERIFIED_UNSUPPORTED,
+                ["WITH CHECK OPTION -> removed for join view"],
+            )
+        )
+    elif remove_check_option:
         patterns_to_remove.append(
             (
                 "clean_view_check_option_clause",
@@ -34541,6 +36015,7 @@ def sanitize_view_ddl(ddl: str, column_names: Optional[Set[str]] = None) -> str:
     cleaned = fix_inline_comment_collapse(ddl)
     if column_names:
         cleaned = repair_split_identifiers(cleaned, column_names)
+    cleaned = strip_view_three_part_column_qualifiers(cleaned)
     return cleaned
 
 
@@ -34653,6 +36128,103 @@ def mask_sql_for_scan(sql: str) -> str:
             in_double = True
             i += 1
             continue
+        i += 1
+    return "".join(chars)
+
+
+def mask_sql_for_reference_scan(sql: str) -> str:
+    """
+    为依赖/作用域文本匹配屏蔽字符串和注释，但保留双引号标识符。
+    这样 quoted owner/object 仍可被正则与 token 预筛命中。
+    """
+    if not sql:
+        return sql
+    if "'" not in sql and "--" not in sql and "/*" not in sql:
+        return sql
+    chars = list(sql)
+    i = 0
+    in_single = False
+    in_q_quote = False
+    q_quote_end = ""
+    in_line_comment = False
+    in_block_comment_depth = 0
+    length = len(chars)
+    q_quote_pairs = {
+        "[": "]",
+        "{": "}",
+        "(": ")",
+        "<": ">",
+    }
+    while i < length:
+        ch = chars[i]
+        nxt = chars[i + 1] if i + 1 < length else ""
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+            else:
+                chars[i] = " "
+            i += 1
+            continue
+        if in_block_comment_depth:
+            chars[i] = " "
+            if ch == "/" and nxt == "*":
+                chars[i + 1] = " "
+                i += 2
+                in_block_comment_depth += 1
+                continue
+            if ch == "*" and nxt == "/":
+                chars[i + 1] = " "
+                i += 2
+                in_block_comment_depth -= 1
+                continue
+            i += 1
+            continue
+        if in_single:
+            chars[i] = " "
+            if ch == "'" and nxt == "'":
+                chars[i + 1] = " "
+                i += 2
+                continue
+            if ch == "'":
+                in_single = False
+            i += 1
+            continue
+        if in_q_quote:
+            chars[i] = " "
+            if ch == q_quote_end and nxt == "'":
+                chars[i + 1] = " "
+                i += 2
+                in_q_quote = False
+                continue
+            i += 1
+            continue
+        if ch == "-" and nxt == "-":
+            chars[i] = " "
+            chars[i + 1] = " "
+            i += 2
+            in_line_comment = True
+            continue
+        if ch == "/" and nxt == "*":
+            chars[i] = " "
+            chars[i + 1] = " "
+            i += 2
+            in_block_comment_depth = 1
+            continue
+        if ch == "'":
+            chars[i] = " "
+            in_single = True
+            i += 1
+            continue
+        if ch in ("q", "Q") and nxt == "'" and i + 2 < length:
+            delimiter = chars[i + 2]
+            if not delimiter.isspace():
+                chars[i] = " "
+                chars[i + 1] = " "
+                chars[i + 2] = " "
+                q_quote_end = q_quote_pairs.get(delimiter, delimiter)
+                in_q_quote = True
+                i += 3
+                continue
         i += 1
     return "".join(chars)
 
@@ -35397,7 +36969,7 @@ def replace_unqualified_table_refs(
                         break
                     scan_pos += 1
                 if not has_following_alias:
-                    replacement = tgt + ' ' + norm_u
+                    replacement = tgt + ' ' + token_raw.strip()
         edits.append((segment_offset + j, segment_offset + k, replacement))
 
     depth_map: List[int] = [0] * length
@@ -35595,8 +37167,10 @@ def remap_view_dependencies(
     synonym_meta = synonym_meta or {}
     source_objects_full_scope = source_objects_full_scope or {}
     source_objects_managed_scope = source_objects_managed_scope or {}
+    live_synonym_scope_source_objects = source_objects_managed_scope or source_objects_full_scope or {}
     object_parent_map = object_parent_map or {}
     preferred_types = ("TABLE", "VIEW", "MATERIALIZED VIEW", "SYNONYM")
+    view_like_types: Set[str] = {"VIEW", "MATERIALIZED VIEW"}
     unresolved_dependencies: List[str] = []
     suppressed_callable_dependencies: List[str] = []
 
@@ -35658,6 +37232,7 @@ def remap_view_dependencies(
         return (terminal_source or "").upper() or None
 
     def _resolve_synonym_for_table_only(owner: str, dep_obj: str) -> Tuple[Optional[str], str]:
+        synonym_full = f"{(owner or '').upper()}.{(dep_obj or '').upper()}".strip(".")
         terminal_source = _resolve_synonym_terminal_for_view_rewrite(owner, dep_obj)
         if not terminal_source:
             return None, "UNRESOLVED"
@@ -35676,6 +37251,18 @@ def remap_view_dependencies(
             return None, "NON_TABLELIKE"
         if not terminal_types:
             return None, "UNRESOLVED"
+        synonym_mapped = None
+        if synonym_full:
+            synonym_mapped = find_mapped_target_any_type(
+                full_object_mapping,
+                synonym_full,
+                preferred_types=("SYNONYM",),
+            )
+            explicit_synonym = remap_rules.get(synonym_full)
+            if explicit_synonym:
+                synonym_mapped = explicit_synonym
+        if terminal_types & view_like_types and synonym_mapped:
+            return synonym_mapped.upper(), "TABLELIKE"
         mapped = find_mapped_target_any_type(
             full_object_mapping,
             terminal_source,
@@ -36164,6 +37751,31 @@ PLSQL_QUALIFIED_REF_PATTERN = re.compile(
     r'(?P<object>"[^"]+"|[A-Z_][A-Z0-9_\$#]*)',
     re.IGNORECASE,
 )
+VIEW_FROM_OBJECT_PATTERN = re.compile(
+    r'\b(?:FROM|JOIN)\s+'
+    r'(?P<schema>"[^"]+"|[A-Z_][A-Z0-9_\$#]*)'
+    r'\s*\.\s*'
+    r'(?P<object>"[^"]+"|[A-Z_][A-Z0-9_\$#]*)',
+    re.IGNORECASE,
+)
+VIEW_THREE_PART_COLUMN_PATTERN = re.compile(
+    r'(?<![A-Z0-9_\$#"])'
+    r'(?P<schema>"[^"]+"|[A-Z_][A-Z0-9_\$#]*)'
+    r'\s*\.\s*'
+    r'(?P<object>"[^"]+"|[A-Z_][A-Z0-9_\$#]*)'
+    r'\s*\.\s*'
+    r'(?P<column>"[^"]+"|[A-Z_][A-Z0-9_\$#]*)'
+    r'(?!\s*\()',
+    re.IGNORECASE,
+)
+VIEW_TWO_PART_COLUMN_PATTERN = re.compile(
+    r'(?<![A-Z0-9_\$#"])'
+    r'(?P<object>"[^"]+"|[A-Z_][A-Z0-9_\$#]*)'
+    r'\s*\.\s*'
+    r'(?P<column>"[^"]+"|[A-Z_][A-Z0-9_\$#]*)'
+    r'(?!\s*\()',
+    re.IGNORECASE,
+)
 
 
 def quote_identifier(name: str) -> str:
@@ -36172,9 +37784,9 @@ def quote_identifier(name: str) -> str:
     text = str(name).strip()
     if not text:
         return text
-    if text.startswith('"') and text.endswith('"'):
-        return text
-    return f'"{text}"'
+    if len(text) >= 2 and text.startswith('"') and text.endswith('"'):
+        text = text[1:-1].replace('""', '"')
+    return f'"{text.replace("\"", "\"\"")}"'
 
 
 def quote_qualified_parts(*parts: str) -> str:
@@ -36199,6 +37811,51 @@ def normalize_qualified_name(name: str) -> Optional[str]:
 
 def ensure_quoted_qualified(name: str) -> str:
     return normalize_qualified_name(name) or name
+
+
+def strip_view_three_part_column_qualifiers(sql: str) -> str:
+    """
+    OceanBase 3.x 的 DBA_VIEWS.TEXT 可能输出 schema.object.column 三段式列引用。
+    OceanBase 4.x 在 CREATE VIEW 时对该写法兼容性较差；当 FROM/JOIN 中 object 名唯一时，
+    去掉 schema 前缀可保持语义并提升执行成功率。
+    """
+    if not sql or sql.count(".") < 2:
+        return sql
+    object_counts: Dict[str, int] = defaultdict(int)
+    from_pairs: Set[Tuple[str, str]] = set()
+    for match in VIEW_FROM_OBJECT_PATTERN.finditer(sql):
+        schema_u = normalize_identifier_name(match.group("schema"))
+        object_u = normalize_identifier_name(match.group("object"))
+        if not schema_u or not object_u:
+            continue
+        from_pairs.add((schema_u, object_u))
+        object_counts[object_u] += 1
+
+    if not from_pairs:
+        return sql
+
+    def _replace(match: re.Match) -> str:
+        schema_u = normalize_identifier_name(match.group("schema"))
+        object_u = normalize_identifier_name(match.group("object"))
+        if (schema_u, object_u) not in from_pairs:
+            return match.group(0)
+        if object_counts.get(object_u, 0) != 1:
+            return match.group(0)
+        return f'{match.group("object")}.{match.group("column")}'
+
+    rewritten = VIEW_THREE_PART_COLUMN_PATTERN.sub(_replace, sql)
+    if len(from_pairs) != 1:
+        return rewritten
+
+    unique_object_u = next(iter(from_pairs))[1]
+
+    def _replace_single_source(match: re.Match) -> str:
+        object_u = normalize_identifier_name(match.group("object"))
+        if object_u != unique_object_u:
+            return match.group(0)
+        return match.group("column")
+
+    return VIEW_TWO_PART_COLUMN_PATTERN.sub(_replace_single_source, rewritten)
 
 
 def format_plsql_qualified_target(
@@ -36226,6 +37883,7 @@ def build_view_ddl_from_text(
 ) -> Optional[str]:
     if not text:
         return None
+    text = strip_view_three_part_column_qualifiers(text)
     view_full = quote_qualified_parts(owner.upper(), name.upper())
     ddl = f"CREATE OR REPLACE VIEW {view_full} AS {text.strip()}"
     upper_text = text.upper()
@@ -36236,6 +37894,14 @@ def build_view_ddl_from_text(
     if not ddl.rstrip().endswith(";"):
         ddl = ddl.rstrip() + ";"
     return ddl
+
+
+def normalize_ob_source_ddl_text(text: Optional[str]) -> Optional[str]:
+    raw = str(text or "")
+    if not raw:
+        return None
+    normalized = raw.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\\t", "\t")
+    return normalized.strip() or None
 
 
 # 批量获取 DDL 的对象类型（仅支持这些类型）
@@ -36333,8 +37999,7 @@ def ob_get_ddl(
     if not ok:
         log.info("[DDL] 读取 OceanBase 源端 DDL 失败 %s.%s (%s): %s", owner, name, obj_type, err)
         return None
-    ddl_text = str(out or "").strip()
-    return ddl_text or None
+    return normalize_ob_source_ddl_text(out)
 
 
 def ob_get_ddl_batch(
@@ -36429,13 +38094,36 @@ def ob_get_source_text(
     return text or None
 
 
+def ob_get_job_action(
+    ob_cfg: ObConfig,
+    owner: str,
+    job_name: str,
+) -> Optional[str]:
+    owner_u = (owner or "").upper()
+    job_u = (job_name or "").upper()
+    sql = """
+        SELECT JOB_ACTION
+        FROM DBA_SCHEDULER_JOBS
+        WHERE OWNER = {owner_name}
+          AND JOB_NAME = {job_name}
+    """.format(
+        owner_name=sql_quote_literal(owner_u),
+        job_name=sql_quote_literal(job_u),
+    )
+    ok, out, err = obclient_run_sql(ob_cfg, sql, quiet_error=True)
+    if not ok:
+        log.info("[JOB_ACTION] 读取 OceanBase 源端 JOB_ACTION 失败 %s.%s: %s", owner, job_name, err)
+        return None
+    return normalize_ob_source_ddl_text(out)
+
+
 def build_source_text_object_ddl(
     obj_type: str,
     owner: str,
     name: str,
     source_text: str,
 ) -> Optional[str]:
-    text = str(source_text or "").strip()
+    text = normalize_ob_source_ddl_text(source_text)
     if not text:
         return None
     obj_type_u = (obj_type or "").upper()
@@ -38327,11 +40015,29 @@ GTT_ON_COMMIT_PATTERN = re.compile(
 )
 
 
+def _apply_masked_regex_substitution(
+    text: str,
+    pattern: re.Pattern,
+    replacement: str,
+) -> str:
+    if not text:
+        return text
+    masked = mask_sql_for_scan(text)
+    matches = list(pattern.finditer(masked))
+    if not matches:
+        return text
+    result = text
+    for match in reversed(matches):
+        replaced = match.expand(replacement)
+        result = result[:match.start()] + replaced + result[match.end():]
+    return result
+
+
 def rewrite_global_temporary_table_to_normal(ddl: str) -> str:
     if not ddl:
         return ddl
-    rewritten = GTT_CREATE_PREFIX_PATTERN.sub(r"\1TABLE", ddl)
-    rewritten = GTT_ON_COMMIT_PATTERN.sub("", rewritten)
+    rewritten = _apply_masked_regex_substitution(ddl, GTT_CREATE_PREFIX_PATTERN, r"\1TABLE")
+    rewritten = _apply_masked_regex_substitution(rewritten, GTT_ON_COMMIT_PATTERN, "")
     return rewritten
 
 
@@ -38340,6 +40046,8 @@ def apply_gtt_table_ddl_handling(
     handling_mode: str,
 ) -> Tuple[str, List[str]]:
     mode_u = normalize_gtt_table_handling_mode(handling_mode)
+    if mode_u == "auto":
+        mode_u = "rewrite_to_normal"
     comments: List[str] = [
         "source_table_kind: GLOBAL TEMPORARY TABLE",
         f"gtt_table_handling_mode: {mode_u}",
@@ -38347,6 +40055,7 @@ def apply_gtt_table_ddl_handling(
     ]
     if mode_u == "rewrite_to_normal":
         comments.append("gtt_rewrite: Oracle GTT clauses removed; target DDL is ordinary TABLE")
+        comments.append("gtt_semantic_notice: rewrite_to_normal loses ON COMMIT transaction-end cleanup semantics")
         return rewrite_global_temporary_table_to_normal(ddl), comments
     if mode_u == "preserve_original":
         comments.append("gtt_rewrite: preserve original Oracle GTT semantics")
@@ -39754,6 +41463,8 @@ def write_fixup_root_readme(
     manual_actions_path: Optional[Path] = None,
     unsupported_grant_count: int = 0,
     deferred_grant_count: int = 0,
+    source_db_mode: Optional[str] = None,
+    source_support_tiers: Optional[Dict[str, object]] = None,
 ) -> Optional[Path]:
     if generated_dirs is None:
         try:
@@ -39802,6 +41513,16 @@ def write_fixup_root_readme(
         intro_steps.append("确认以上风险项后，再按默认顺序执行 run_fixup.py。")
     for idx, step in enumerate(intro_steps, start=1):
         lines.append(f"{idx}. {step}")
+
+    if normalize_source_db_mode(source_db_mode or SOURCE_DB_MODE_ORACLE) == SOURCE_DB_MODE_OCEANBASE:
+        contract_lines = build_ob_source_contract_summary_lines(source_support_tiers)
+        if contract_lines:
+            lines.extend([
+                "",
+                "# OB->OB support contract",
+            ])
+            for item in contract_lines:
+                lines.append(f"- {item}")
 
     lines.extend([
         "",
@@ -40657,7 +42378,10 @@ def generate_alter_for_table_columns(
                     info,
                     prefer_ob_varchar=True
                 )
-                novalidate_meta = src_notnull_novalidate_cols.get(col_name.upper(), {})
+                novalidate_meta = src_notnull_novalidate_cols.get(
+                    normalize_semantic_identifier_name(col_name),
+                    {},
+                )
                 source_cons = novalidate_meta.get("constraint_name") or ""
                 search_condition = novalidate_meta.get("search_condition") or f"{quote_identifier(col_name.upper())} IS NOT NULL"
                 suggested_name = _build_collision_preferred_name(
@@ -41812,7 +43536,13 @@ def generate_fixup_scripts(
         progress_log_interval = 10.0
     progress_log_interval = max(1.0, progress_log_interval)
     synonym_meta_map = synonym_metadata or {}
+    raw_source_objects_managed_scope = source_objects_managed_scope
     source_objects_managed_scope = source_objects_managed_scope or {}
+    live_synonym_scope_source_objects = (
+        raw_source_objects_managed_scope
+        if raw_source_objects_managed_scope is not None
+        else (source_objects_full_scope or {})
+    )
     object_parent_map = object_parent_map or {}
     view_dependency_map = view_dependency_map or {}
     view_callable_dep_map = view_callable_dep_map or {}
@@ -41942,7 +43672,10 @@ def generate_fixup_scripts(
         for item in (settings.get("enabled_primary_types") or set())
         if str(item).strip()
     }
-    if not ({"VIEW", "MATERIALIZED VIEW"} & enabled_primary_types_cfg):
+    if (
+        str(settings.get("source_db_mode", "oracle")).strip().lower() != "oceanbase"
+        and not ({"VIEW", "MATERIALIZED VIEW"} & enabled_primary_types_cfg)
+    ):
         fallback_view_keys = load_oracle_view_like_object_keys(
             ora_cfg,
             settings.get("source_schemas_list", []) or []
@@ -43086,7 +44819,8 @@ def generate_fixup_scripts(
     def is_temporary_support_row(row: Optional[ObjectSupportReportRow]) -> bool:
         if not row:
             return False
-        return is_temp_table_blacklist_reason_code(row.reason_code)
+        reason_code_u = (row.reason_code or "").upper()
+        return is_temp_table_blacklist_reason_code(reason_code_u) or reason_code_u == OB_SOURCE_TEMP_TABLE_MANUAL_ONLY_REASON_CODE
 
     for (obj_type, tgt_name, src_name) in tv_results.get('missing', []):
         obj_type_u = obj_type.upper()
@@ -43112,7 +44846,7 @@ def generate_fixup_scripts(
                     src_schema_u,
                     src_obj_u,
                     synonym_meta_map,
-                    full_object_mapping,
+                    live_synonym_scope_source_objects,
                     remap_rules=remap_rules,
                 )
                 if live_scope_state != "in_scope":
@@ -44244,6 +45978,47 @@ def generate_fixup_scripts(
                     else:
                         log.warning("[FIXUP] TABLE %s.%s 的 dbcat DDL 为 unsupported，DBMS_METADATA 兜底失败，仍输出原始 DDL 供人工处理。", ss, st)
                 mark_source('TABLE', ddl_source_label or 'missing')
+                provider_fidelity = get_ob_source_ddl_provider_fidelity('TABLE', ddl_source_label)
+                if (
+                    source_db_mode == SOURCE_DB_MODE_OCEANBASE
+                    and provider_fidelity != OB_SOURCE_DDL_FIDELITY_CERTIFIED
+                ):
+                    support_row = build_ob_source_low_fidelity_table_support_row(
+                        ss,
+                        st,
+                        ts,
+                        tt,
+                        ddl_source_label,
+                    )
+                    reason_token = normalize_filtered_grant_reason_token(support_row.reason_code).lower()
+                    with table_lock:
+                        table_skip_counts[reason_token] += 1
+                    filename = f"{ts}.{tt}.sql"
+                    header = f"不支持 TABLE 占位说明 {ts}.{tt} (源: {ss}.{st})"
+                    subdir = "tables_unsupported/temporary" if is_ob_source_temp_table_key(oracle_meta, ss, st) else "tables_unsupported"
+                    log.info(
+                        "[FIXUP] TABLE %s.%s 命中低保真 provider=%s，转为 unsupported/manual-only 占位文件。",
+                        ss,
+                        st,
+                        ddl_source_label,
+                    )
+                    write_fixup_file(
+                        base_dir,
+                        subdir,
+                        filename,
+                        build_unsupported_object_placeholder_sql(
+                            "TABLE",
+                            ss,
+                            st,
+                            ts,
+                            tt,
+                            support_row,
+                        ),
+                        header,
+                        extra_comments=build_support_comments(support_row),
+                    )
+                    progress_label = ddl_source_label.lower()
+                    return
                 ddl_adj = adjust_ddl_for_object(
                     ddl,
                     ss,
@@ -44333,7 +46108,10 @@ def generate_fixup_scripts(
         for src_schema, src_table, tgt_schema, tgt_table, support_row in missing_tables_unsupported:
             def _job(ss=src_schema, st=src_table, ts=tgt_schema, tt=tgt_table, sr=support_row):
                 try:
-                    if (sr.reason_code or "").upper() == NESTED_TABLE_STORAGE_REASON_CODE:
+                    if (sr.reason_code or "").upper() in {
+                        NESTED_TABLE_STORAGE_REASON_CODE,
+                        OB_SOURCE_TEMP_TABLE_MANUAL_ONLY_REASON_CODE,
+                    }:
                         ddl_adj = build_unsupported_object_placeholder_sql(
                             "TABLE",
                             ss,
@@ -44344,14 +46122,16 @@ def generate_fixup_scripts(
                         )
                         filename = f"{ts}.{tt}.sql"
                         header = f"不支持 TABLE 占位说明 {ts}.{tt} (源: {ss}.{st})"
+                        subdir = "tables_unsupported/temporary" if is_temporary_support_row(sr) else "tables_unsupported"
                         log.info(
-                            "[FIXUP] TABLE %s.%s 为 nested table storage，不生成普通 TABLE DDL，改写入 unsupported 占位文件。",
+                            "[FIXUP] TABLE %s.%s 因 reason_code=%s 不生成普通 TABLE DDL，改写入 unsupported 占位文件。",
                             ss,
                             st,
+                            sr.reason_code or "-",
                         )
                         write_fixup_file(
                             base_dir,
-                            "tables_unsupported",
+                            subdir,
                             filename,
                             ddl_adj,
                             header,
@@ -44797,6 +46577,22 @@ def generate_fixup_scripts(
                 log.error("[FIXUP] 处理 VIEW %s.%s 时出错: %s", src_schema, src_obj, exc)
 
     view_refresh_targets: List[Tuple[str, str, str, str]] = []
+    view_refresh_seen: Set[Tuple[str, str, str, str]] = set()
+
+    def _append_view_refresh_target(src_schema: str, src_obj: str, tgt_schema: str, tgt_obj: str) -> None:
+        item = (
+            (src_schema or "").upper(),
+            (src_obj or "").upper(),
+            (tgt_schema or "").upper(),
+            (tgt_obj or "").upper(),
+        )
+        if not all(item):
+            return
+        if item in view_refresh_seen:
+            return
+        view_refresh_seen.add(item)
+        view_refresh_targets.append(item)
+
     if grant_enabled and views_with_missing_prereq:
         target_to_source = build_target_to_source_mapping(full_object_mapping)
         for view_full in sorted(views_with_missing_prereq):
@@ -44818,7 +46614,33 @@ def generate_fixup_scripts(
             tgt_schema, tgt_obj = view_full_u.split(".", 1)
             if not allow_fixup("VIEW", tgt_schema, src_schema):
                 continue
-            view_refresh_targets.append((src_schema, src_obj, tgt_schema, tgt_obj))
+            _append_view_refresh_target(src_schema, src_obj, tgt_schema, tgt_obj)
+
+    if source_db_mode == SOURCE_DB_MODE_OCEANBASE and scope_mode == "remap_root_closure":
+        existing_target_views = {
+            (name or "").upper()
+            for name in ((ob_meta.objects_by_type or {}).get("VIEW", set()) if ob_meta else set())
+            if (name or "").strip()
+        }
+        missing_view_targets = {
+            f"{tgt_schema}.{tgt_obj}".upper()
+            for _src_schema, _src_obj, tgt_schema, tgt_obj in view_missing_supported
+        }
+        for src_full_u, obj_types in sorted((source_objects_managed_scope or {}).items()):
+            type_set = {(item or "").upper() for item in (obj_types or set()) if item}
+            if "VIEW" not in type_set or "." not in (src_full_u or ""):
+                continue
+            tgt_full = get_mapped_target(full_object_mapping, src_full_u, "VIEW") or src_full_u
+            tgt_full_u = (tgt_full or "").upper()
+            if not tgt_full_u or "." not in tgt_full_u:
+                continue
+            if tgt_full_u not in existing_target_views or tgt_full_u in missing_view_targets:
+                continue
+            src_schema, src_obj = src_full_u.split(".", 1)
+            tgt_schema, tgt_obj = tgt_full_u.split(".", 1)
+            if not allow_fixup("VIEW", tgt_schema, src_schema):
+                continue
+            _append_view_refresh_target(src_schema, src_obj, tgt_schema, tgt_obj)
 
     if view_refresh_targets:
         log.info("[FIXUP] (4a/9) 正在生成 %d 个 VIEW refresh 脚本...", len(view_refresh_targets))
@@ -46562,6 +48384,8 @@ def generate_fixup_scripts(
         report_dir,
         report_timestamp,
         generated_dirs=generated_fixup_dirs,
+        source_db_mode=settings.get("source_db_mode"),
+        source_support_tiers=settings.get("source_support_tiers"),
     )
     settings["_fixup_root_readme_path"] = str(fixup_root_readme_path) if fixup_root_readme_path else ""
     if fixup_root_readme_path:
@@ -47160,6 +48984,22 @@ def build_runtime_change_notices(
             "0.9.8.6",
             "当前运行可能不是全量范围",
             f"本次启用了 object_created_before；after-cutoff 对象请结合 {report_index_hint} 继续核对。",
+        ))
+    gtt_runtime_diagnostics = list((settings or {}).get("_gtt_runtime_diagnostics") or [])
+    for idx, message in enumerate(gtt_runtime_diagnostics, start=1):
+        notices.append(RuntimeNotice(
+            f"gtt_mode_diag_{idx}",
+            "0.9.9.4",
+            "GTT 处理模式已按版本/兼容性调整",
+            message,
+        ))
+    gtt_state = (settings or {}).get("_gtt_handling_state")
+    if gtt_state and any((row.fixup_behavior or "").upper() == "REWRITE_TO_NORMAL_TABLE" for row in (gtt_state.detail_rows or [])):
+        notices.append(RuntimeNotice(
+            "gtt_rewrite_semantic_notice",
+            "0.9.9.4",
+            "GTT rewrite 会改变事务语义",
+            "rewrite_to_normal 会丢失 ON COMMIT 事务结束自动清理语义；请先看 gtt_transform_detail 与 manual_actions_required。",
         ))
     return notices
 
@@ -49114,12 +50954,15 @@ def build_mode_aware_gtt_handling_state(
             oms_excluded_table_keys=set(),
             detail_rows=[],
         )
+    effective_mode, gtt_diagnostics = resolve_effective_gtt_table_handling_mode(settings)
+    settings["_gtt_runtime_diagnostics"] = list(gtt_diagnostics or [])
+    settings["_effective_gtt_table_handling_mode"] = effective_mode
     return build_gtt_handling_state(
         blacklist_tables,
         table_target_map,
         oracle_meta,
         ob_meta,
-        settings.get("gtt_table_handling_mode", "rewrite_to_normal"),
+        effective_mode,
     )
 
 
@@ -50720,16 +52563,16 @@ def build_fatal_error_matrix_rows(settings: Optional[Dict]) -> List[FatalErrorMa
         ),
         FatalErrorMatrixRow(
             category="SCOPED_TRIGGER_LIST",
-            trigger_condition="remap_root_closure + trigger_list，但未启用 TRIGGER 检查、trigger_list 读失败、或存在非法条目",
+            trigger_condition="explicit_roots/remap_root_closure + trigger_list，但未启用 TRIGGER 检查、trigger_list 读失败、或存在非法条目",
             default_behavior="FATAL_ABORT",
-            currently_relevant="YES" if source_scope_mode == "remap_root_closure" and bool(trigger_list_path) else "NO",
+            currently_relevant="YES" if is_scoped_source_mode(source_scope_mode) and bool(trigger_list_path) else "NO",
             remediation="启用 check_extra_types=TRIGGER，并修正 trigger_list 文件格式/路径。",
         ),
         FatalErrorMatrixRow(
             category="SCOPED_ROOTS",
-            trigger_condition="remap_root_closure 下 remap_file 中没有可用的 TABLE/VIEW roots",
+            trigger_condition="explicit_roots/remap_root_closure 下 remap_file 中没有可用的 TABLE/VIEW roots",
             default_behavior="FATAL_ABORT",
-            currently_relevant="YES" if source_scope_mode == "remap_root_closure" else "NO",
+            currently_relevant="YES" if is_scoped_source_mode(source_scope_mode) else "NO",
             remediation="在 remap_file 中至少提供一个有效 TABLE/VIEW 根对象。",
         ),
         FatalErrorMatrixRow(
@@ -55433,10 +57276,15 @@ def save_report_to_db(
 
     source_mode = normalize_source_db_mode(settings.get("source_db_mode", SOURCE_DB_MODE_ORACLE))
     if source_mode == SOURCE_DB_MODE_OCEANBASE:
-        deferred_fixup_types = sorted(OB_SOURCE_FIXUP_DEFERRED_TYPES)
+        support_tiers = settings.get("source_support_tiers") or build_ob_source_support_tier_matrix()
+        version_pair = str((support_tiers or {}).get("version_pair") or "").strip() or "unknown -> unknown"
+        deferred_summary = build_ob_source_family_tier_summary(
+            support_tiers,
+            tiers={SOURCE_SUPPORT_TIER_PREVIEW, SOURCE_SUPPORT_TIER_MANUAL_ONLY},
+        ) or "<none>"
         conclusion_detail = (
             f"{conclusion_detail}; source_mode=oceanbase; "
-            f"fixup_deferred={','.join(deferred_fixup_types) if deferred_fixup_types else '<none>'}"
+            f"version_pair={version_pair}; fixup_deferred={deferred_summary}"
         )
 
     if store_scope in {"core", "full"}:
@@ -56119,6 +57967,8 @@ def build_run_summary(
     grant_plan: Optional[GrantPlan] = None,
     object_counts_summary: Optional[ObjectCountSummary] = None,
     context_summary: Optional[Dict[str, object]] = None,
+    source_support_tiers: Optional[Dict[str, object]] = None,
+    settings: Optional[Dict[str, object]] = None,
 ) -> RunSummary:
     end_time = datetime.now()
     total_seconds = time.perf_counter() - ctx.start_perf
@@ -56294,6 +58144,7 @@ def build_run_summary(
     ddl_cleanup_preserved_rows = int(ddl_cleanup_summary.get("preserved_rows", 0) or 0)
     ddl_cleanup_semantic_rows = int(ddl_cleanup_summary.get("semantic_rewrite_rows", 0) or 0)
     context_summary = dict(context_summary or {})
+    context_inventory_health = str(context_summary.get("inventory_health") or CONTEXT_INVENTORY_HEALTH_HEALTHY)
     context_missing_cnt = int(context_summary.get("missing", 0) or 0)
     context_mismatch_cnt = int(context_summary.get("mismatch", 0) or 0)
     context_extra_target_cnt = int(context_summary.get("extra_target", 0) or 0)
@@ -56310,6 +58161,13 @@ def build_run_summary(
         item for item in runtime_degraded_rows
         if item.scope == RUNTIME_DEGRADED_SCOPE_ARTIFACT
     ]
+    gtt_runtime_diagnostics = list((settings or {}).get("_gtt_runtime_diagnostics") or [])
+    gtt_state = (settings or {}).get("_gtt_handling_state")
+    gtt_rewrite_total = sum(
+        1
+        for row in ((gtt_state.detail_rows or []) if gtt_state else [])
+        if (row.fixup_behavior or "").upper() == "REWRITE_TO_NORMAL_TABLE"
+    )
     findings: List[str] = [
         f"主对象: 缺失 {missing_count}, 不匹配 {mismatched_count}, 多余 {extra_target_cnt}, 仅打印 {skipped_count}"
     ]
@@ -56330,6 +58188,8 @@ def build_run_summary(
                 manual=context_manual_cnt,
             )
         )
+    if context_inventory_health != CONTEXT_INVENTORY_HEALTH_HEALTHY:
+        findings.append(f"CONTEXT inventory 健康状态: {context_inventory_health}")
     if ddl_cleanup_applied_rows or ddl_cleanup_preserved_rows:
         findings.append(
             "DDL 清理/改写: 应用 {applied}, 语义改写 {semantic}, 保留提醒 {preserved}".format(
@@ -56396,6 +58256,12 @@ def build_run_summary(
                 role=int(grant_mode_skip_counts.get("role_privileges", 0) or 0),
             )
         )
+    if normalize_source_db_mode(ctx.source_db_mode) == SOURCE_DB_MODE_OCEANBASE:
+        findings.extend(build_ob_source_contract_summary_lines(source_support_tiers))
+    if gtt_rewrite_total:
+        findings.append(f"GTT rewrite_to_normal: {gtt_rewrite_total} 个对象已转普通 TABLE，存在事务语义损失")
+    for message in gtt_runtime_diagnostics:
+        findings.append(f"GTT 兼容诊断: {message}")
     if extra_object_grant_count:
         if extra_grant_detail_path:
             findings.append(
@@ -56495,8 +58361,21 @@ def build_run_summary(
         attention.append("触发器中存在 SCHEMA.OBJECT.COLUMN 形式的字符串路径，程序已保守保留原文，请人工确认。")
     if ddl_cleanup_semantic_rows:
         attention.append("本次 fixup 中存在 DDL 语义改写，请优先复核 ddl_cleanup_detail 明细和脚本头注释。")
+    if gtt_rewrite_total:
+        attention.append("存在 GTT rewrite_to_normal，对应对象会丢失 ON COMMIT 自动清理语义，请优先复核 gtt_transform_detail。")
     if context_missing_cnt or context_mismatch_cnt or context_extra_target_cnt or context_unresolved_cnt:
         attention.append("存在 application context 缺失/漂移/未解析引用，需复核 context_detail 与 context_reference_detail。")
+    if context_inventory_health != CONTEXT_INVENTORY_HEALTH_HEALTHY:
+        attention.append("application context inventory 已降级，context 相关 extra/missing 结论需要结合降级提示人工复核。")
+    if normalize_source_db_mode(ctx.source_db_mode) == SOURCE_DB_MODE_OCEANBASE:
+        deferred_summary = build_ob_source_family_tier_summary(
+            source_support_tiers,
+            tiers={SOURCE_SUPPORT_TIER_PREVIEW, SOURCE_SUPPORT_TIER_MANUAL_ONLY},
+        )
+        if deferred_summary:
+            attention.append(
+                f"OB->OB 仍有 deferred/manual-only families: {deferred_summary}；这些对象不要视为 certified auto-fix 闭环。"
+            )
     if ddl_cleanup_preserved_rows:
         attention.append("部分 Oracle 子句已改为默认保留策略，需结合目标环境确认是否仍需人工精简。")
     if runtime_compare_events:
@@ -58382,6 +60261,8 @@ def print_final_report(
             grant_plan=grant_plan,
             object_counts_summary=object_counts_summary,
             context_summary=context_summary,
+            source_support_tiers=(settings.get("source_support_tiers") if settings else None),
+            settings=settings,
         )
         notice_state_path, notice_state = load_notice_state(settings.get("config_dir") if settings else None)
         runtime_notices = build_runtime_change_notices(
@@ -59262,6 +61143,8 @@ def print_final_report(
                 manual_actions_path=manual_actions_path,
                 unsupported_grant_count=unsupported_grant_count,
                 deferred_grant_count=deferred_grant_count,
+                source_db_mode=(settings.get("source_db_mode") if settings else None),
+                source_support_tiers=(settings.get("source_support_tiers") if settings else None),
             )
             if refreshed_fixup_root_readme_path:
                 settings["_fixup_root_readme_path"] = str(refreshed_fixup_root_readme_path)
@@ -59437,6 +61320,7 @@ def parse_cli_args() -> argparse.Namespace:
 
 def main():
     """主执行函数"""
+    build_qualified_rewrite_specs.cache_clear()
     args = parse_cli_args()
     config_file = args.config
     config_path = Path(config_file).resolve()
@@ -59485,6 +61369,10 @@ def main():
         ob_env_info = collect_ob_env_info(ob_cfg)
         settings["_source_env_info"] = dict(source_env_info or {})
         settings["_target_env_info"] = dict(ob_env_info or {})
+        settings["source_support_tiers"] = build_ob_source_support_tier_matrix(
+            source_env_info.get("version"),
+            ob_env_info.get("version"),
+        ) if source_db_mode == SOURCE_DB_MODE_OCEANBASE else {}
         endpoint_info = {
             "source_engine": source_engine,
             "source": source_env_info,
@@ -59552,6 +61440,7 @@ def main():
             enabled_primary_types,
             enabled_extra_types
         )
+        config_diagnostics.extend(list(settings.get("_compatibility_default_diagnostics") or []))
         source_mode_diagnostics = list(settings.get("_source_mode_diagnostics") or [])
         source_mode_diagnostics.extend(
             build_source_mode_diagnostics(
@@ -59561,6 +61450,7 @@ def main():
         )
         if source_mode_diagnostics:
             config_diagnostics.extend(source_mode_diagnostics)
+        config_diagnostics = dedupe_preserve_order(config_diagnostics)
         if config_diagnostics:
             log_subsection("配置诊断")
             for item in config_diagnostics:
@@ -59611,6 +61501,8 @@ def main():
     manual_trigger_blacklist_table_keys: Set[Tuple[str, str]] = set()
     explicit_seed_nodes: Set[DependencyNode] = set()
     system_artifact_seed_nodes: Set[DependencyNode] = set()
+    synonym_meta: Dict[Tuple[str, str], SynonymMeta] = {}
+    managed_source_terminal_schemas: List[str] = []
 
     log_section("对象映射准备")
     apply_config_hot_reload_at_phase(hot_reload_runtime, "对象映射准备", settings, ora_cfg, ob_cfg)
@@ -59656,6 +61548,7 @@ def main():
             cutoff_text = format_object_created_ts(cutoff_dt)
             created_map = load_source_object_created_map(
                 ora_cfg,
+                settings,
                 settings['source_schemas_list'],
                 source_objects,
                 synonym_check_scope=settings.get('synonym_check_scope', 'public_only'),
@@ -59742,14 +61635,37 @@ def main():
                 or settings.get('scope_integrity_fk_check')
             )
         )
+        synonym_terminal_diagnostic_rows: List[Tuple[str, str, str, str]] = []
         scope_discovery_types = build_scope_discovery_types(
             enabled_object_types,
             source_scope_mode_setting,
         )
-
+        managed_source_terminal_schemas = sorted({
+            full_name.split('.', 1)[0].upper()
+            for full_name in source_objects.keys()
+            if '.' in full_name
+        })
+        if source_capabilities.get("supports_source_synonym_metadata", False):
+            synonym_meta = load_source_synonym_metadata(
+                ora_cfg,
+                settings,
+                settings['source_schemas_list'],
+                allowed_terminal_source_schemas=managed_source_terminal_schemas,
+            )
+        else:
+            synonym_meta = {}
+        if source_capabilities.get("supports_source_parent_map", False):
+            object_parent_map = load_source_parent_map(
+                ora_cfg,
+                settings,
+                settings['source_schemas_list'],
+                enabled_object_types=scope_discovery_types,
+                known_source_types=source_objects,
+                diagnostic_rows=synonym_terminal_diagnostic_rows,
+                synonym_meta=synonym_meta,
+            )
         # 4.1) 获取依附对象（如 TRIGGER）的父表映射，用于 one-to-many schema 拆分场景
-        synonym_terminal_diagnostic_rows: List[Tuple[str, str, str, str]] = []
-        object_parent_map = {}
+        object_parent_map = object_parent_map or {}
         
         # 4.2) 加载源端依赖关系（用于智能推导一对多场景的目标 schema）
         oracle_dependencies_internal: List[DependencyRecord] = []
@@ -59822,6 +61738,34 @@ def main():
                 if source_dependencies_set is None:
                     source_dependencies_set = set()
                 source_dependencies_set.update(supplemental_dependency_set)
+        if source_scope_mode_setting == "remap_root_closure" and source_db_mode == SOURCE_DB_MODE_OCEANBASE:
+            supplemental_dependency_records = []
+            default_sequence_dependency_records = load_ob_source_default_sequence_dependency_records(
+                source_ob_cfg,
+                source_objects,
+            )
+            supplemental_dependency_records.extend(default_sequence_dependency_records)
+            if remap_scope_text_fallback_mode == "off":
+                supplemental_dependency_records.extend(
+                    load_ob_job_action_dependency_records(
+                        source_ob_cfg,
+                        source_objects,
+                        runtime_degraded_events=settings.get("_runtime_degraded_events"),
+                    )
+                )
+            if supplemental_dependency_records:
+                oracle_dependencies_internal.extend(supplemental_dependency_records)
+                oracle_dependencies_for_grants.extend(supplemental_dependency_records)
+                supplemental_dependency_set = {
+                    (
+                        dep.owner.upper(), dep.name.upper(), dep.object_type.upper(),
+                        dep.referenced_owner.upper(), dep.referenced_name.upper(), dep.referenced_type.upper(),
+                    )
+                    for dep in supplemental_dependency_records
+                }
+                if source_dependencies_set is None:
+                    source_dependencies_set = set()
+                source_dependencies_set.update(supplemental_dependency_set)
         dependency_graph: DependencyGraph = build_dependency_graph(source_dependencies_set) if source_dependencies_set else {}
         scope_integrity_dependency_graph_raw: DependencyGraph = {}
         view_dependency_map: Dict[Tuple[str, str], Set[str]] = build_view_dependency_map(
@@ -59859,13 +61803,14 @@ def main():
         source_scope_mode = normalize_source_object_scope_mode(
             settings.get("source_object_scope_mode", "full_source")
         )
-        if source_scope_mode == "remap_root_closure":
+        if is_scoped_source_mode(source_scope_mode):
             trigger_list_path_scoped = settings.get("trigger_list", "").strip()
             trigger_entries_scoped: Set[str] = set()
             if trigger_list_path_scoped:
                 if "TRIGGER" not in enabled_extra_types:
                     log.error(
-                        "严重错误: source_object_scope_mode=remap_root_closure 且已配置 trigger_list，但 check_extra_types 未启用 TRIGGER。"
+                        "严重错误: source_object_scope_mode=%s 且已配置 trigger_list，但 check_extra_types 未启用 TRIGGER。",
+                        source_scope_mode,
                     )
                     abort_run()
                 entries, invalid_entries, duplicate_entries, _total_lines, read_error = parse_trigger_list_file(
@@ -59873,7 +61818,8 @@ def main():
                 )
                 if read_error:
                     log.error(
-                        "严重错误: source_object_scope_mode=remap_root_closure 且 trigger_list 读取失败: %s",
+                        "严重错误: source_object_scope_mode=%s 且 trigger_list 读取失败: %s",
+                        source_scope_mode,
                         read_error,
                     )
                     abort_run()
@@ -59883,14 +61829,16 @@ def main():
                         for line_no, entry, _reason in invalid_entries[:10]
                     )
                     log.error(
-                        "严重错误: source_object_scope_mode=remap_root_closure 下 trigger_list 存在 %d 条非法条目: %s",
+                        "严重错误: source_object_scope_mode=%s 下 trigger_list 存在 %d 条非法条目: %s",
+                        source_scope_mode,
                         len(invalid_entries),
                         sample_text,
                     )
                     abort_run()
                 if duplicate_entries:
                     log.warning(
-                        "trigger_list 在 remap_root_closure 模式下存在 %d 条重复条目，已按去重结果继续。",
+                        "trigger_list 在 %s 模式下存在 %d 条重复条目，已按去重结果继续。",
+                        source_scope_mode,
                         len(duplicate_entries),
                     )
                 trigger_entries_scoped = set(entries or set())
@@ -59901,7 +61849,8 @@ def main():
             )
             if not root_seed_nodes:
                 log.error(
-                    "严重错误: source_object_scope_mode=remap_root_closure 但 remap_file 中没有可用的显式 TABLE/VIEW roots。"
+                    "严重错误: source_object_scope_mode=%s 但 remap_file 中没有可用的显式 TABLE/VIEW roots。",
+                    source_scope_mode,
                 )
                 abort_run()
 
@@ -59913,8 +61862,9 @@ def main():
             )
             if missing_trigger_entries:
                 log.warning(
-                    "source_object_scope_mode=remap_root_closure 下 trigger_list 中有 %d 个触发器未在源端对象范围内解析到；"
+                    "source_object_scope_mode=%s 下 trigger_list 中有 %d 个触发器未在源端对象范围内解析到；"
                     "这些条目将仅进入报告，不会进入作用域闭包或 fixup: %s",
+                    source_scope_mode,
                     len(missing_trigger_entries),
                     ", ".join(sorted(missing_trigger_entries[:10])),
                 )
@@ -59932,8 +61882,9 @@ def main():
                 explicit_trigger_detail_rows=explicit_trigger_detail_rows,
                 mode=source_scope_mode,
             )
-            if remap_scope_text_fallback_mode == "safe":
+            if source_scope_mode == "remap_root_closure" and remap_scope_text_fallback_mode == "safe":
                 source_scope_result, text_fallback_added = apply_scoped_text_reference_fallback(
+                    settings,
                     ora_cfg,
                     source_scope_result,
                     source_objects,
@@ -59947,16 +61898,18 @@ def main():
                         "[SOURCE_SCOPE] safe text fallback 累计纳入 %d 个对象。",
                         text_fallback_added,
                     )
-            source_scope_result, pruned_scoped_synonyms = enforce_scoped_synonym_terminal_scope(
-                source_scope_result,
-                source_objects,
-                object_parent_map,
-            )
-            if pruned_scoped_synonyms:
-                log.info(
-                    "[SOURCE_SCOPE] 因 synonym terminal 已超出 remap_root_closure，额外过滤 SYNONYM=%d。",
-                    pruned_scoped_synonyms,
+            pruned_scoped_synonyms = 0
+            if source_scope_mode == "remap_root_closure":
+                source_scope_result, pruned_scoped_synonyms = enforce_scoped_synonym_terminal_scope(
+                    source_scope_result,
+                    source_objects,
+                    object_parent_map,
                 )
+                if pruned_scoped_synonyms:
+                    log.info(
+                        "[SOURCE_SCOPE] 因 synonym terminal 已超出 remap_root_closure，额外过滤 SYNONYM=%d。",
+                        pruned_scoped_synonyms,
+                    )
             detail_rows = list(source_scope_result.detail_rows or ())
             for status, obj_type, full_u, detail in explicit_trigger_detail_rows:
                 if status == "TRIGGER_KEEP_SKIPPED":
@@ -59973,7 +61926,8 @@ def main():
             if non_root_skipped:
                 sample = ", ".join(f"{full}({types_text})" for full, types_text in non_root_skipped[:5])
                 log.warning(
-                    "source_object_scope_mode=remap_root_closure 下有 %d 个 remap roots 因非合法 root 类型被跳过: %s",
+                    "source_object_scope_mode=%s 下有 %d 个 remap roots 因非合法 root 类型被跳过: %s",
+                    source_scope_mode,
                     len(non_root_skipped),
                     sample,
                 )
@@ -60019,7 +61973,8 @@ def main():
             view_callable_dep_map = build_view_callable_dep_map(source_dependencies_set) if source_dependencies_set else {}
 
             log.info(
-                "[SOURCE_SCOPE] remap_root_closure 生效: roots=%d, explicit_triggers=%d, included_nodes=%d, filtered_nodes=%d, source_objects=%d->%d, deps=%d->%d, parent_links=%d->%d, remap_conflicts=%d->%d, remap_rules=%d。",
+                "[SOURCE_SCOPE] %s 生效: roots=%d, explicit_triggers=%d, included_nodes=%d, filtered_nodes=%d, source_objects=%d->%d, deps=%d->%d, parent_links=%d->%d, remap_conflicts=%d->%d, remap_rules=%d。",
+                source_scope_mode,
                 len(source_scope_result.root_seed_nodes),
                 len(source_scope_result.explicit_trigger_nodes),
                 len(source_scope_result.included_nodes),
@@ -60045,6 +62000,13 @@ def main():
                 mode=source_scope_mode,
             )
         settings["_source_scope_result"] = source_scope_result
+        if source_scope_result:
+            heuristic_view_deps = build_view_dependency_map_from_scope_detail_rows(
+                source_scope_result.detail_rows,
+            )
+            if heuristic_view_deps:
+                for key, refs in heuristic_view_deps.items():
+                    view_dependency_map.setdefault(key, set()).update(refs)
         # 4.2.b) 预计算递归依赖表集合（性能优化：避免每对象 DFS）
         transitive_table_cache: Optional[TransitiveTableCache] = None
         if settings.get("enable_schema_mapping_infer") and dependency_graph:
@@ -60133,32 +62095,6 @@ def main():
             full_object_mapping
         )
         target_schemas: Set[str] = set(managed_target_scope.target_schemas)
-        managed_source_terminal_schemas = sorted({
-            full_name.split('.', 1)[0].upper()
-            for full_name in source_objects.keys()
-            if '.' in full_name
-        })
-        # 4.3) 缓存同义词元数据，供 PUBLIC 等大规模同义词快速生成 DDL。
-        # 这里按“源端实际受管范围”过滤 PUBLIC 终点，不再把 source_schemas 直接混作 target 口径。
-        if source_capabilities.get("supports_source_synonym_metadata", False):
-            synonym_meta = load_source_synonym_metadata(
-                ora_cfg,
-                settings,
-                settings['source_schemas_list'],
-                allowed_terminal_source_schemas=managed_source_terminal_schemas,
-            )
-        else:
-            synonym_meta = {}
-        if source_capabilities.get("supports_source_parent_map", False):
-            object_parent_map = load_source_parent_map(
-                ora_cfg,
-                settings,
-                settings['source_schemas_list'],
-                enabled_object_types=scope_discovery_types,
-                known_source_types=source_objects_full_scope,
-                diagnostic_rows=synonym_terminal_diagnostic_rows,
-                synonym_meta=synonym_meta,
-            )
         target_table_pairs = collect_table_pairs(master_list, use_target=True)
 
     report_dir_setting = settings.get('report_dir', 'main_reports').strip() or 'main_reports'
@@ -60549,6 +62485,7 @@ def main():
                     target_ob_cfg=ob_cfg,
                 )
             )
+            config_diagnostics = dedupe_preserve_order(config_diagnostics)
 
         exclude_rules = settings.get("exclude_object_rules", []) or []
         explicit_seed_nodes: Set[DependencyNode] = set()
@@ -61054,7 +62991,7 @@ def main():
             ob_meta,
             oracle_meta,
             monitored_types,
-            suppress_unmanaged_target_extras=(settings.get("source_object_scope_mode") == "remap_root_closure"),
+            suppress_unmanaged_target_extras=is_scoped_source_mode(settings.get("source_object_scope_mode")),
         )
         tv_results = check_primary_objects(
             master_list,
@@ -61065,7 +63002,7 @@ def main():
             print_only_types,
             settings.get("effective_print_only_primary_reasons"),
             settings=settings,
-            suppress_unmanaged_target_extras=(settings.get("source_object_scope_mode") == "remap_root_closure"),
+            suppress_unmanaged_target_extras=is_scoped_source_mode(settings.get("source_object_scope_mode")),
             managed_target_objects=build_managed_target_object_set(full_object_mapping),
             transformed_blacklist_columns_by_table=(
                 blacklist_rehydration_state.transformed_columns_by_table
@@ -61188,6 +63125,19 @@ def main():
             context_fixup_mode=settings.get("context_fixup_mode", "manual"),
             target_package_objects=target_package_objects,
             planned_package_targets=planned_package_targets,
+            target_package_statuses={
+                f"{owner}.{name}": status
+                for (owner, name, obj_type), status in ((ob_meta.object_statuses or {}).items())
+                if (obj_type or "").upper() == "PACKAGE" and owner and name
+            },
+            source_inventory_health=str(
+                getattr(oracle_meta, "context_inventory_health", CONTEXT_INVENTORY_HEALTH_HEALTHY)
+                or CONTEXT_INVENTORY_HEALTH_HEALTHY
+            ),
+            target_inventory_health=str(
+                getattr(ob_meta, "context_inventory_health", CONTEXT_INVENTORY_HEALTH_HEALTHY)
+                or CONTEXT_INVENTORY_HEALTH_HEALTHY
+            ),
         )
         settings["_context_reference_rows"] = list(context_results.reference_rows or [])
         settings["_context_detail_rows"] = list(context_results.detail_rows or [])
@@ -61341,7 +63291,11 @@ def main():
                 skipped_dependency_pairs,
                 ob_meta,
                 ob_grant_catalog=dependency_grant_catalog,
-                managed_target_objects=build_managed_target_object_set(full_object_mapping) if settings.get("source_object_scope_mode") == "remap_root_closure" else None,
+                managed_target_objects=(
+                    build_managed_target_object_set(full_object_mapping)
+                    if is_scoped_source_mode(settings.get("source_object_scope_mode"))
+                    else None
+                ),
             )
             log.info(
                 "[DEPENDENCY] 依赖校验完成: missing=%d, unexpected=%d, skipped=%d",

--- a/tests_context_fixup_regressions.py
+++ b/tests_context_fixup_regressions.py
@@ -27,7 +27,7 @@ import schema_diff_reconciler as sdr
 
 
 class TestRunFixupRegressionScenarios(unittest.TestCase):
-    def test_non_smart_order_places_view_refresh_after_view(self):
+    def test_non_smart_order_places_synonym_and_refresh_before_view(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             fixup_dir = Path(tmpdir) / "fixup"
             (fixup_dir / "view").mkdir(parents=True)
@@ -47,8 +47,8 @@ class TestRunFixupRegressionScenarios(unittest.TestCase):
             files = rf.collect_sql_files_by_layer(fixup_dir, smart_order=False)
             order = [str(path.relative_to(fixup_dir)) for _, path in files]
 
-            self.assertLess(order.index("view/A.V1.sql"), order.index("view_refresh/A.V1.sql"))
-            self.assertLess(order.index("view_refresh/A.V1.sql"), order.index("synonym/A.S1.sql"))
+            self.assertLess(order.index("synonym/A.S1.sql"), order.index("view_refresh/A.V1.sql"))
+            self.assertLess(order.index("view_refresh/A.V1.sql"), order.index("view/A.V1.sql"))
             self.assertLess(order.index("view_refresh/A.V1.sql"), order.index("materialized_view/A.MV1.sql"))
 
 
@@ -162,7 +162,7 @@ class TestContextRegressionScenarios(unittest.TestCase):
         try:
             sdr.oracledb.connect = lambda **_kwargs: FakeConnection()
             with mock.patch.object(sdr.log, "debug") as debug_mock:
-                contexts, err = sdr.load_oracle_context_inventory(
+                contexts, err, health = sdr.load_oracle_context_inventory(
                     {"user": "u", "password": "p", "dsn": "d"},
                     {"SRC"},
                 )
@@ -172,7 +172,9 @@ class TestContextRegressionScenarios(unittest.TestCase):
             else:
                 sdr.oracledb.connect = orig_connect
 
-        self.assertIsNone(err)
+        self.assertIsNotNone(err)
+        self.assertIn("fallback_to_simplified_dba_context", err)
+        self.assertEqual(health, sdr.CONTEXT_INVENTORY_HEALTH_DEGRADED)
         self.assertEqual(contexts["APP_CTX"].type, sdr.CONTEXT_MODE_LOCAL)
         debug_mock.assert_called()
         self.assertIn("load_oracle_context_inventory 降级", debug_mock.call_args[0][0])


### PR DESCRIPTION
## Summary
- ship the v0.9.9.4 remediation train for the 2026-04-17 audit follow-up
- harden scope/context/GTT/executor paths without regressing the Oracle -> OB baseline
- sync docs/config guidance and cut the release version markers to 0.9.9.4

## Validation
- [x] `.venv/bin/python -m py_compile $(git ls-files '*.py')`
- [x] `.venv/bin/python -m unittest`
- [x] `openspec validate fix-review-report-0417-remediation-train --strict`
- [x] `.venv/bin/python schema_diff_reconciler.py /tmp/config.oracle.regression.ini`
- [x] `.venv/bin/python run_fixup.py /tmp/config.oracle.regression.ini --glob "__NO_MATCH__"`
- [x] `.venv/bin/python schema_diff_reconciler.py /tmp/config.ob.product.reportdb.ini`
- [x] report_db verification for `report_id=20260417_100719_2799d6d9`: `WRITE_STATUS=READY`, `WRITE_EXPECTED_ROWS=1062`, `WRITE_ACTUAL_ROWS=1062`, `DETAIL=25`, `DETAIL_ITEM=31`, `FIXUP_SKIP=1`, `ARTIFACT_LINE=807`
