### PR TITLE
fix: embed default compatibility registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # OceanBase Comparator Toolkit
 
-> 当前版本：V0.9.9.6-hotfix2
+> 当前版本：V0.9.9.6-hotfix3
 > 面向 Oracle → OceanBase 与 OceanBase → OceanBase 的结构一致性校验与修补脚本生成工具  
 > 核心理念：一次转储、本地对比、脚本审计优先
 
-## 近期更新（0.9.9.6-hotfix2）
+## 近期更新（0.9.9.6-hotfix3）
+- Hotfix：`compatibility_registry.json` 不再是默认路径下的硬阻断文件；若客户漏拷该文件，主程序会使用内置默认兼容矩阵继续运行并给出 warning。只有显式配置了自定义 `compatibility_registry_path` 时，文件缺失或格式错误才会 fail-fast。
 - Hotfix：补齐 0.9.9.6+ 的交付包约束和启动期缺文件提示；`schema_diff_reconciler.py`、`run_fixup.py`、`diagnostic_bundle.py` 需要同目录内的内部模块 `comparator_reliability.py`，请使用 toolkit zip 或整仓更新，不要只替换单个脚本。
 - Hotfix：修复 OB -> OB 模式下目标端 SYNONYM 可能统计为 0 的问题；目标端 OceanBase 元数据转储现在会在 OB source 模式下补查 `DBA_SYNONYMS`。
 - 新增发布门禁、实库 smoke evidence、运行心跳、timeout 摘要、recovery manifest、兼容矩阵和独立诊断包，正式发版前必须通过 release gate。
@@ -75,11 +76,12 @@
 - 运行账号需具备 DBA_* 视图访问权限（Oracle 与 OB）
 - 安全说明：工具运行时不会把 OB/dbcat 密码作为明文参数暴露在 `ps` 命令中（配置文件仍按当前方式保留密码项）。
 
-## 运维提示（0.9.9.6-hotfix2）
+## 运维提示（0.9.9.6-hotfix3）
 - Oracle -> OB：默认链路不变；默认 BYTE 语义的 VARCHAR/VARCHAR2 compare/fixup 以 `DATA_LENGTH` 为准，只有 `CHAR_USED='C'` 明确字符语义时才按字符长度且不做扩容。若省略 `synonym_check_scope/synonym_fixup_scope`，仍按 `public_only` 运行。target-side `DBA_SYNONYMS` 补查不再静默扩大 Oracle 源默认范围；OB -> OB 路径会对源端和目标端同时启用补查。
 - OB -> OB：若省略 `synonym_check_scope/synonym_fixup_scope`，运行时会提示并按 `all` 处理；OB source 的多行 `DATA_DEFAULT` 会先做控制字符清理，避免错列。
 - GTT：可继续显式使用 `rewrite_to_normal/preserve_original/blocked`；也可以用 `auto` 让程序按目标 OB 版本决策。凡是落到 `rewrite_to_normal`，都要把它视为“结构可迁、事务语义需人工确认”。
 - scoped closure：`safe` 文本补盲现在支持静态 `DBMS_SCHEDULER.CREATE_JOB/CREATE_SCHEDULE`；如果 `job_name/schedule_name` 不是静态字面量，报告会提示 unresolved，而不会盲猜。
+- 交付文件最小边界：主程序必须与 `comparator_reliability.py` 同目录；`compatibility_registry.json` 和 `blacklist_rules.json` 建议随 toolkit 一起交付用于审计和黑名单规则，但默认 `compatibility_registry.json` 漏拷不再阻断运行。
 
 ## 贡献方式
 

--- a/comparator_reliability.py
+++ b/comparator_reliability.py
@@ -43,6 +43,135 @@ COMPAT_DECISION_MANUAL = "manual"
 COMPAT_DECISION_UNSUPPORTED = "unsupported"
 
 DEFAULT_COMPATIBILITY_REGISTRY = "compatibility_registry.json"
+BUILTIN_COMPATIBILITY_REGISTRY = {
+    "schema_version": 1,
+    "version": "2026.04.29",
+    "description": (
+        "Comparator compatibility decisions for Oracle/OceanBase source modes "
+        "and OceanBase targets."
+    ),
+    "entries": [
+        {
+            "source_mode": "oracle",
+            "min_ob_version": "4.0.0.0",
+            "object_family": "TABLE",
+            "operation": "compare_columns",
+            "decision": "supported",
+            "rationale": (
+                "TABLE column presence, VARCHAR/VARCHAR2 byte window, CHAR semantics "
+                "exactness, defaults, nullability, identity, and visibility are "
+                "supported by metadata compare."
+            ),
+            "manual_action_hint": "",
+        },
+        {
+            "source_mode": "oracle",
+            "min_ob_version": "4.0.0.0",
+            "object_family": "TABLE",
+            "operation": "alter_shape_fixup",
+            "decision": "degraded",
+            "rationale": (
+                "ALTER TABLE ADD/MODIFY/default/nullability changes may lock, "
+                "rewrite, or depend on target data state."
+            ),
+            "manual_action_hint": "Review generated table_alter SQL and target data before execution.",
+        },
+        {
+            "source_mode": "oracle",
+            "min_ob_version": "4.0.0.0",
+            "object_family": "VIEW",
+            "operation": "create_or_replace",
+            "decision": "degraded",
+            "rationale": (
+                "VIEW DDL is generated from source DDL with remap and compatibility "
+                "cleanup; invalid dependencies or DBLINK usage can require manual "
+                "intervention."
+            ),
+            "manual_action_hint": "Review view compatibility details, prerequisites, and generated grants before execution.",
+        },
+        {
+            "source_mode": "oracle",
+            "min_ob_version": "4.0.0.0",
+            "object_family": "TRIGGER",
+            "operation": "create_or_replace",
+            "decision": "degraded",
+            "rationale": (
+                "Trigger DDL may contain schema references, non-table targets, "
+                "temporary-table semantics, or literal object paths requiring review."
+            ),
+            "manual_action_hint": "Review trigger detail reports and generated trigger SQL.",
+        },
+        {
+            "source_mode": "oracle",
+            "min_ob_version": "4.0.0.0",
+            "object_family": "GRANT",
+            "operation": "generate",
+            "decision": "degraded",
+            "rationale": (
+                "Grant compatibility depends on target privilege catalog, object "
+                "availability, and source grantor semantics."
+            ),
+            "manual_action_hint": "Review grant capability and unsupported grant reports before execution.",
+        },
+        {
+            "source_mode": "oracle",
+            "min_ob_version": "4.0.0.0",
+            "object_family": "JOB",
+            "operation": "fixup",
+            "decision": "manual",
+            "rationale": "Scheduler and job semantics are not certified for automatic execution in 0.9.x.",
+            "manual_action_hint": "Use generated artifacts as a conversion reference only.",
+        },
+        {
+            "source_mode": "oracle",
+            "min_ob_version": "4.0.0.0",
+            "object_family": "SCHEDULE",
+            "operation": "fixup",
+            "decision": "manual",
+            "rationale": "Schedule semantics are operator-owned in 0.9.x.",
+            "manual_action_hint": "Review schedule conversion manually.",
+        },
+        {
+            "source_mode": "oracle",
+            "min_ob_version": "4.0.0.0",
+            "object_family": "MATERIALIZED_VIEW",
+            "operation": "fixup",
+            "decision": "manual",
+            "rationale": "Materialized view compatibility varies by refresh mode and query features.",
+            "manual_action_hint": "Treat generated materialized view artifacts as manual review input.",
+        },
+        {
+            "source_mode": "oceanbase",
+            "min_ob_version": "4.0.0.0",
+            "object_family": "TABLE",
+            "operation": "compare_columns",
+            "decision": "supported",
+            "rationale": "OB source mode uses 1:1 column type and length comparison without Oracle byte expansion.",
+            "manual_action_hint": "",
+        },
+        {
+            "source_mode": "oceanbase",
+            "min_ob_version": "4.0.0.0",
+            "object_family": "GRANT",
+            "operation": "generate",
+            "decision": "degraded",
+            "rationale": (
+                "OB source privilege extraction is supported but still depends on "
+                "target catalog and runtime grantability."
+            ),
+            "manual_action_hint": "Review grant capability detail before execution.",
+        },
+        {
+            "source_mode": "*",
+            "min_ob_version": "4.0.0.0",
+            "object_family": "COMPILE",
+            "operation": "execute",
+            "decision": "supported",
+            "rationale": "Existing-object ALTER COMPILE is the first-wave safe execution family.",
+            "manual_action_hint": "",
+        },
+    ],
+}
 DECISION_CONFIG_KEYS = {
     "source_db_mode",
     "source_schemas",
@@ -691,9 +820,18 @@ def resolve_compatibility_registry_path(settings: Dict[str, object], base_dir: P
     return path.resolve()
 
 
-def load_compatibility_registry(path: Path) -> Dict[str, object]:
-    path = Path(path)
-    data = json.loads(path.read_text(encoding="utf-8"))
+def _copy_builtin_compatibility_registry() -> Dict[str, object]:
+    return {
+        "schema_version": BUILTIN_COMPATIBILITY_REGISTRY["schema_version"],
+        "version": BUILTIN_COMPATIBILITY_REGISTRY["version"],
+        "description": BUILTIN_COMPATIBILITY_REGISTRY["description"],
+        "entries": [dict(entry) for entry in BUILTIN_COMPATIBILITY_REGISTRY["entries"]],
+    }
+
+
+def _finalize_compatibility_registry(
+    data: Dict[str, object], *, registry_path: str, registry_sha1: str
+) -> Dict[str, object]:
     if not isinstance(data, dict):
         raise ValueError("compatibility registry must be a JSON object")
     version = data.get("version")
@@ -721,9 +859,33 @@ def load_compatibility_registry(path: Path) -> Dict[str, object]:
             raise ValueError(
                 f"compatibility registry entry {idx} has unsupported decision: {decision}"
             )
-    data["_path"] = str(path)
-    data["_sha1"] = file_sha1(path)
+    data["_path"] = registry_path
+    data["_sha1"] = registry_sha1
     return data
+
+
+def load_compatibility_registry(
+    path: Path, *, allow_builtin_fallback: bool = False
+) -> Dict[str, object]:
+    path = Path(path)
+    if path.exists():
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return _finalize_compatibility_registry(
+            data, registry_path=str(path), registry_sha1=file_sha1(path)
+        )
+    if allow_builtin_fallback:
+        data = _copy_builtin_compatibility_registry()
+        logging.getLogger(__name__).warning(
+            "未找到默认 compatibility_registry.json: %s；已使用程序内置默认兼容矩阵继续运行。"
+            "交付客户时仍建议使用完整 toolkit zip，便于审计 registry 内容。",
+            path,
+        )
+        return _finalize_compatibility_registry(
+            data,
+            registry_path=f"builtin:{DEFAULT_COMPATIBILITY_REGISTRY}",
+            registry_sha1=stable_json_hash(data),
+        )
+    raise FileNotFoundError(f"compatibility registry not found: {path}")
 
 
 def _version_tokens(value: str) -> Tuple[int, ...]:

--- a/diagnostic_bundle.py
+++ b/diagnostic_bundle.py
@@ -35,7 +35,7 @@ except ModuleNotFoundError as exc:
         raise SystemExit(2) from exc
     raise
 
-TOOL_VERSION = "0.9.9.6-hotfix2"
+TOOL_VERSION = "0.9.9.6-hotfix3"
 SECRET_RE = re.compile(
     r"(password|passwd|pwd|token|secret|private[_-]?key|credential|wallet)", re.IGNORECASE
 )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+## [0.9.9.6-hotfix3] - 2026-04-30
+
+### 修复
+- 内置默认兼容矩阵 registry，默认 `compatibility_registry.json` 漏拷时不再阻断主程序运行；显式配置自定义 `compatibility_registry_path` 时仍保持严格校验。
+- 同步交付文档，明确 `comparator_reliability.py` 是必须同目录的内部模块，`compatibility_registry.json` 为建议随包保留的审计文件，`blacklist_rules.json` 为黑名单规则条件依赖。
+
 ## [0.9.9.6-hotfix2] - 2026-04-30
 
 ### 修复

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # 数据库对象对比工具 - 跨平台打包与执行指南 (Wheelhouse 版)
 
-> 适用版本：V0.9.9.6-hotfix2
+> 适用版本：V0.9.9.6-hotfix3
 
 > 适用场景：需要在无网络或不同机器上运行本工具，且保持源码不改。  
 > 方案：wheelhouse + venv，无需 PyInstaller。
@@ -24,7 +24,7 @@ pip wheel --wheel-dir=./wheelhouse -r requirements.txt
 若需为其他平台或 Python 小版本打包，需使用对应平台标签。
 
 ## 2. 打包部署目录建议
-0.9.9.6+ 请按完整目录交付，不要只替换单个 `schema_diff_reconciler.py`。`comparator_reliability.py` 是项目内部公共模块，必须与主程序、`run_fixup.py`、`diagnostic_bundle.py` 放在同一目录；它不是 pip 包。
+0.9.9.6+ 请按完整目录交付，不要只替换单个 `schema_diff_reconciler.py`。`comparator_reliability.py` 是项目内部公共模块，必须与主程序、`run_fixup.py`、`diagnostic_bundle.py` 放在同一目录；它不是 pip 包。`compatibility_registry.json` 建议随包保留用于审计，漏拷时会使用内置默认 registry；`blacklist_rules.json` 在 `blacklist_mode=auto/rules_only` 时需要保留，否则黑名单规则会被跳过。
 
 ```
 deployment_package/

--- a/readme_config.txt
+++ b/readme_config.txt
@@ -1,10 +1,10 @@
 配置说明 (config.ini)
-版本：0.9.9.6-hotfix2（更新日期：2026-04-30）
+版本：0.9.9.6-hotfix3（更新日期：2026-04-30）
 本文件为完整配置说明书，覆盖所有可配置项（含最近新增功能）。
 
 本版重点增加生产可靠性与诊断能力：release evidence 门禁、运行心跳、timeout 摘要、recovery manifest、fixup 安全分层、兼容矩阵和独立诊断包；同时保留 Oracle source 默认 BYTE 语义下 VARCHAR/VARCHAR2 长度基准修复。
 
-部署约束：0.9.9.6+ 需要使用完整 toolkit 目录或整仓更新。`schema_diff_reconciler.py`、`run_fixup.py`、`diagnostic_bundle.py` 都依赖同目录内的内部文件 `comparator_reliability.py`；这不是 pip 包，不需要也不能通过 `pip install comparator_reliability` 解决。
+部署约束：0.9.9.6+ 需要使用完整 toolkit 目录或整仓更新。`schema_diff_reconciler.py`、`run_fixup.py`、`diagnostic_bundle.py` 都依赖同目录内的内部文件 `comparator_reliability.py`；这不是 pip 包，不需要也不能通过 `pip install comparator_reliability` 解决。`compatibility_registry.json` 建议随包保留用于审计；0.9.9.6-hotfix3 起默认路径漏拷时会使用内置默认 registry，不再阻断运行。
 
 通用约定
 - 布尔值：true/false/1/0/yes/no（大小写不敏感）。
@@ -340,7 +340,7 @@
   主程序会在 run 目录写 `run_heartbeat_<timestamp>.json`，run_fixup 会在 fixup_dir 写 `run_fixup_heartbeat_<timestamp>.json`。
 - slow_phase_warning_sec：主程序阶段级慢操作告警阈值（秒）。默认：300；最小 1。
 - slow_sql_warning_sec：run_fixup 单文件/单语句慢执行告警阈值（秒）。默认：60；最小 1。
-- compatibility_registry_path：兼容矩阵 registry 路径。默认留空，加载随工具发布的 `compatibility_registry.json`；若指定文件且格式错误，主程序会在 compare 前失败。
+- compatibility_registry_path：兼容矩阵 registry 路径。默认留空，优先加载随工具发布的 `compatibility_registry.json`；若默认文件漏拷，使用程序内置默认 registry 并继续运行。若显式指定自定义路径且文件缺失或格式错误，主程序会在 compare 前失败。
 - checkpoint_enable：是否写入 `recovery_manifest_<timestamp>.json`。默认：true。
 - resume_manifest：主程序恢复校验入口，指向上一轮 `recovery_manifest_*.json`；也可用 CLI `--resume-manifest` 覆盖。
   说明：恢复默认要求决定性配置、工具版本和输入工件 hash 一致；日志路径、报告路径、心跳间隔等运行态配置变化允许恢复并记录。
@@ -510,4 +510,4 @@ dbcat 配置
 - 语法检查：`python3 -m py_compile $(git ls-files '*.py')`
 - 单元测试：`.venv/bin/python -m unittest discover -v`
 - 可选联调（需真实 Oracle/OB）：`schema_diff_reconciler.py config.ini` 后执行 `run_fixup.py config.ini --glob "__NO_MATCH__"` 做链路冒烟验证。
-- 建议保留并随包分发：`blacklist_rules.json`（blacklist_mode=auto/rules_only 时需要）
+- 建议保留并随包分发：`blacklist_rules.json`（blacklist_mode=auto/rules_only 时需要）、`compatibility_registry.json`（用于审计；漏拷时有内置默认兜底）

--- a/readme_lite.txt
+++ b/readme_lite.txt
@@ -1,10 +1,11 @@
 OceanBase 对比工具极简手册（现场版）
-当前版本：V0.9.9.6-hotfix2
+当前版本：V0.9.9.6-hotfix3
 
 0. 先更新版本
 - 项目地址：https://github.com/Minorli/ob_comparator
 - 建议整仓更新，不要只替换单个脚本。
 - 当前版本同时支持 Oracle → OceanBase 与 OceanBase → OceanBase（Oracle mode source）两种校验/修补模式。
+- 0.9.9.6-hotfix3 将默认兼容矩阵内置；漏拷 compatibility_registry.json 不再阻断运行，但完整交付包仍会带该文件用于审计。
 - 0.9.9.6-hotfix2 补齐交付包约束：主程序、修复执行器和诊断包都需要同目录内的 comparator_reliability.py；它是项目内部文件，不是 pip 包。
 - 0.9.9.6-hotfix1 修复 OB -> OB 模式目标端 SYNONYM 可能统计为 0 的问题；建议整仓更新，不要只替换单个脚本。
 - 0.9.9.5 修复 Oracle source 默认 BYTE 语义下 VARCHAR2 长度误判与 DDL 类型字面量问题；如遇到 `VARCHAR2` 被生成成 `VARCHAR` 或长度回缩，请更新到本版后重跑。
@@ -17,7 +18,7 @@ OceanBase 对比工具极简手册（现场版）
 - config.ini（由 config.ini.template.txt 复制）
 - remap_rules.txt（remap 规则）
 - blacklist_rules.json（黑名单规则）
-- compatibility_registry.json（兼容矩阵规则）
+- compatibility_registry.json（建议随包保留；漏拷时使用内置默认规则）
 - exclude_objects.txt（可选：手工排除对象）
 - trigger_list.txt（可选：触发器白名单，config.ini 里 trigger_list= 指向它）
 

--- a/run_fixup.py
+++ b/run_fixup.py
@@ -94,7 +94,7 @@ try:
 except Exception:  # pragma: no cover - non-POSIX fallback
     fcntl = None
 
-__version__ = "0.9.9.6-hotfix2"
+__version__ = "0.9.9.6-hotfix3"
 
 CONFIG_DEFAULT_PATH = "config.ini"
 DEFAULT_FIXUP_DIR = "fixup_scripts"

--- a/schema_diff_reconciler.py
+++ b/schema_diff_reconciler.py
@@ -16,7 +16,7 @@
 
 """
 
-数据库对象对比工具 (V0.9.9.6-hotfix2 - Dump-Once, Compare-Locally + 依赖 + ALTER 修补 + 注释校验)
+数据库对象对比工具 (V0.9.9.6-hotfix3 - Dump-Once, Compare-Locally + 依赖 + ALTER 修补 + 注释校验)
 ---------------------------------------------------------------------------
 功能概要：
 1. 对比 Oracle (源) 与 OceanBase (目标) 的：
@@ -33,7 +33,7 @@
    - INDEX / CONSTRAINT：校验存在性与列组合（含唯一性/约束类型）。
    - SEQUENCE / TRIGGER：校验存在性；依赖：映射后生成期望依赖并对比目标端。
 
-3. 性能架构 (V0.9.9.6-hotfix2 核心)：
+3. 性能架构 (V0.9.9.6-hotfix3 核心)：
    - OceanBase 侧采用“一次转储，本地对比”：
        使用少量 obclient 调用，分别 dump：
          DBA_OBJECTS
@@ -152,7 +152,7 @@ except ModuleNotFoundError as exc:
         raise SystemExit(2) from exc
     raise
 
-__version__ = "0.9.9.6-hotfix2"
+__version__ = "0.9.9.6-hotfix3"
 
 __author__ = "Minor Li"
 REPO_URL = "https://github.com/Minorli/ob_comparator"
@@ -10511,7 +10511,7 @@ def run_config_wizard(config_path: Path) -> None:
     _prompt_field(
         "SETTINGS",
         "compatibility_registry_path",
-        "兼容矩阵 registry 路径（留空使用随工具发布的 compatibility_registry.json）",
+        "兼容矩阵 registry 路径（留空优先使用随工具发布的 compatibility_registry.json，漏拷时使用内置默认 registry）",
         default=cfg.get("SETTINGS", "compatibility_registry_path", fallback=""),
     )
     _prompt_field(
@@ -64924,7 +64924,7 @@ def parse_cli_args() -> argparse.Namespace:
             progress_log_interval 主程序/run_fixup 心跳与进度日志间隔（秒，默认 10）
             slow_phase_warning_sec 主程序阶段级慢操作告警阈值（秒，默认 300）
             slow_sql_warning_sec run_fixup 单文件/单语句慢执行告警阈值（秒，默认 60）
-            compatibility_registry_path 兼容矩阵 registry 路径（留空使用随工具发布的 compatibility_registry.json）
+            compatibility_registry_path 兼容矩阵 registry 路径（留空优先使用随工具发布的 compatibility_registry.json，漏拷时用内置默认 registry）
             checkpoint_enable     true/false 控制 recovery_manifest_<ts>.json 输出
             diagnostic_include_sql_content true/false 控制诊断包是否默认包含 SQL 正文（默认 false）
             diagnostic_redact_identifiers true/false 控制诊断包标识符脱敏
@@ -65884,8 +65884,14 @@ def main():
     log.info(f"本次报告将输出到: {report_path}")
     RUN_OPERATION_TRACKER = setup_main_runtime_observability(settings, report_dir, timestamp)
     compatibility_registry_path = resolve_compatibility_registry_path(settings, config_path.parent)
+    compatibility_registry_custom = bool(
+        str(settings.get("compatibility_registry_path") or "").strip()
+    )
     try:
-        compatibility_registry = load_compatibility_registry(compatibility_registry_path)
+        compatibility_registry = load_compatibility_registry(
+            compatibility_registry_path,
+            allow_builtin_fallback=not compatibility_registry_custom,
+        )
     except Exception as exc:
         log.error("兼容矩阵 registry 无效: %s (%s)", compatibility_registry_path, exc)
         abort_run()
@@ -65899,14 +65905,16 @@ def main():
             object_families=enabled_object_types | {"COMPILE", "GRANT"},
         )
     )
-    settings["_compatibility_registry_path"] = str(compatibility_registry_path)
+    settings["_compatibility_registry_path"] = str(compatibility_registry.get("_path") or "")
     settings["_compatibility_registry_sha1"] = str(compatibility_registry.get("_sha1") or "")
     settings["_compatibility_matrix_path"] = str(compatibility_matrix_path)
     settings["_compatibility_summary_path"] = str(compatibility_summary_path)
     settings["_compatibility_matrix_entries"] = list(compatibility_entries)
     log.info("兼容矩阵已输出: %s", compatibility_matrix_path)
     if settings.get("checkpoint_enable", True):
-        recovery_inputs = [config_path, compatibility_registry_path]
+        recovery_inputs = [config_path]
+        if Path(compatibility_registry_path).exists():
+            recovery_inputs.append(compatibility_registry_path)
         remap_file_raw = str(settings.get("remap_file") or "").strip()
         if remap_file_raw:
             recovery_inputs.append(resolve_path_from_config(config_path, remap_file_raw))


### PR DESCRIPTION
## Summary

- embed the default compatibility registry so missing default `compatibility_registry.json` no longer aborts the main program
- keep strict validation for explicitly configured custom `compatibility_registry_path`
- document the actual delivery boundary: `comparator_reliability.py` is required, `compatibility_registry.json` is recommended/auditable, `blacklist_rules.json` is conditional for blacklist rules
- bump user-facing version labels to `0.9.9.6-hotfix3`

## Root Cause

0.9.9.6 moved the compatibility matrix rules to `compatibility_registry.json` and treated the default file as a hard runtime input. Customers who copied only the main script plus the newly required internal module still failed when the registry file was not present.

## Verification

- default missing registry probe: passed, returns `builtin:compatibility_registry.json`
- custom missing registry probe: passed, fails fast with `FileNotFoundError`
- built-in registry equality check against tracked `compatibility_registry.json`: passed
- full-directory import probe returned `0.9.9.6-hotfix3`
- `schema_diff_reconciler.py --help` shows `0.9.9.6-hotfix3` and updated registry guidance
- `python -m py_compile $(git ls-files '*.py')`: passed
- `ruff check schema_diff_reconciler.py run_fixup.py diagnostic_bundle.py comparator_reliability.py init_users_roles.py`: passed
- `git diff --check`: passed
- `python -m pytest`: 1160 passed, 2 skipped
- minimal-directory real DB smoke with only `schema_diff_reconciler.py` + `comparator_reliability.py` and no `compatibility_registry.json`: passed; report `main_reports/run_20260430_160811/report_20260430_160811.txt`
- `run_fixup.py config.ini --plan-only`: passed, no SQL execution
- diagnostic bundle for the fallback smoke: passed, manifest `tool_version=0.9.9.6-hotfix3`

## Impact

No compare/fixup database semantics changed. The default registry file is now optional at runtime because the same content is embedded; explicit custom registry paths remain strict.
