### PR TITLE
chore: add GitHub project governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Minorli

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,72 @@
+---
+name: Bug report
+about: Report a defect or regression
+title: "[bug] "
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+-
+
+## Severity
+
+- [ ] production blocker
+- [ ] data correctness risk
+- [ ] fixup execution risk
+- [ ] report/noise issue
+- [ ] documentation or packaging issue
+
+## Observed Behavior
+
+-
+
+## Expected Behavior
+
+-
+
+## Reproduction Clues
+
+- Compare command:
+- Fixup command:
+- Object(s):
+- Config switches:
+
+## Artifacts
+
+- report path:
+- detail file:
+- fixup file:
+- DB error / stack trace:
+
+Do not attach credentials, full `config.ini`, Oracle wallet files, or customer data.
+
+## Environment
+
+- Source DB:
+- Target DB:
+- Tool version / commit:
+
+## Related Area
+
+- [ ] `#1` synonym
+- [ ] `#2` constraint
+- [ ] `#3` view
+- [ ] `#4` scope
+- [ ] `#5` grant
+- [ ] `#6` runtime / parser / metadata fallback
+- [ ] `#7` blacklist re-entry
+- [ ] `#9` reporting / report_db
+- [ ] `#10` fixup safety / table presence
+- [ ] `#11` trigger / view-chain
+- [ ] `#12` cutoff scope
+- [ ] `#13` hot reload
+- [ ] `#14` name collision / SYS_C
+- [ ] not sure
+
+## Regression?
+
+- [ ] yes
+- [ ] no
+- [ ] unknown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Latest release
+    url: https://github.com/Minorli/ob_comparator/releases/latest
+    about: Download the current toolkit package and review release verification notes.
+  - name: Documentation index
+    url: https://github.com/Minorli/ob_comparator/blob/main/docs/README.md
+    about: Start here for architecture, deployment, release, and advanced usage documents.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,46 @@
+---
+name: Feature request
+about: Propose a new capability or workflow improvement
+title: "[feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+-
+
+## Desired Behavior
+
+-
+
+## Scope
+
+- affected object types:
+- config changes:
+- report changes:
+- fixup changes:
+- OpenSpec change required: yes / no / unknown
+
+## Why This Matters
+
+-
+
+## Risks / Boundaries
+
+-
+
+## Validation Expectation
+
+- [ ] OpenSpec validation required
+- [ ] unit tests only
+- [ ] real Oracle + OB verification required
+- [ ] report/report_db consistency verification required
+
+## Related Existing Area
+
+- Refs #
+
+## Additional Context
+
+-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,66 @@
+## Summary
+
+-
+
+## Related Issues
+
+- Refs #
+
+## Change Type
+
+- [ ] Bug fix
+- [ ] New capability
+- [ ] Config or workflow change
+- [ ] Report or report_db change
+- [ ] Docs only
+- [ ] Refactor
+
+## What Changed
+
+-
+
+## Validation
+
+Commands executed:
+
+```bash
+python3 -m py_compile $(git ls-files '*.py')
+```
+
+Additional commands:
+
+```bash
+# add the exact commands you ran
+```
+
+Results:
+
+- [ ] `py_compile` passed
+- [ ] unit tests passed
+- [ ] real Oracle + OB verification passed
+- [ ] report summary/detail/report_db counts verified where applicable
+- [ ] real DB verification not applicable
+- [ ] blocker explained below
+
+## Impact Scope
+
+-
+
+## Release / Packaging Impact
+
+- [ ] no release impact
+- [ ] version strings updated consistently
+- [ ] release evidence updated
+- [ ] toolkit package / customer deployment note updated
+
+## Risks / Follow-ups
+
+-
+
+## Checklist
+
+- [ ] Linked to an issue
+- [ ] OpenSpec updated and validated when required
+- [ ] Config/docs updated when user-facing behavior changed
+- [ ] No secrets or local artifacts included
+- [ ] Security-sensitive behavior reviewed, or not applicable

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Hong_Kong
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Asia/Hong_Kong
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compile tracked Python files
+        run: python -m py_compile $(git ls-files '*.py')
+
+      - name: Check whitespace in changed files
+        shell: bash
+        run: |
+          if [ -n "${{ github.base_ref }}" ]; then
+            git diff --check "origin/${{ github.base_ref }}...HEAD"
+          else
+            git diff --check HEAD~1..HEAD
+          fi

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,20 @@
+# Code of Conduct
+
+This project expects direct, professional collaboration.
+
+## Expected Behavior
+
+- Be respectful and specific when discussing defects, regressions, and design tradeoffs.
+- Keep reports reproducible and sanitized.
+- Assume migration tooling can affect production systems, and treat safety concerns seriously.
+- Separate technical disagreement from personal criticism.
+
+## Unacceptable Behavior
+
+- Sharing credentials, customer data, private connection details, or proprietary artifacts in public issues or pull requests.
+- Harassment, threats, personal attacks, or discriminatory language.
+- Repeatedly derailing technical discussions after maintainers have set scope.
+
+## Enforcement
+
+Maintainers may edit or remove unsafe public content, close off-topic discussions, or restrict participation when needed to protect users and the project.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # OceanBase Comparator Toolkit
 
+[![CI](https://github.com/Minorli/ob_comparator/actions/workflows/ci.yml/badge.svg)](https://github.com/Minorli/ob_comparator/actions/workflows/ci.yml)
+[![Latest Release](https://img.shields.io/github/v/release/Minorli/ob_comparator)](https://github.com/Minorli/ob_comparator/releases/latest)
+[![License](https://img.shields.io/github/license/Minorli/ob_comparator)](LICENSE)
+
 > 当前版本：V0.9.9.6-hotfix5
 > 面向 Oracle → OceanBase 与 OceanBase → OceanBase 的结构一致性校验与修补脚本生成工具  
 > 核心理念：一次转储、本地对比、脚本审计优先

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are prioritized for the latest public 0.9.9.x hotfix line and the current `main` branch.
+
+Older hotfixes may receive guidance or a forward-upgrade recommendation instead of a backport.
+
+## Reporting a Vulnerability
+
+Do not open a public issue for suspected vulnerabilities, exposed credentials, customer data, or SQL execution safety problems.
+
+Use GitHub private vulnerability reporting when available. If it is not available, contact the maintainer privately and include:
+
+- affected version or commit
+- source and target database modes
+- minimal reproduction steps
+- sanitized error output or report snippets
+- whether the issue can generate or execute unsafe fixup SQL
+
+Do not include real passwords, full connection strings, Oracle wallet files, production `config.ini`, or customer data.
+
+## Handling Expectations
+
+The maintainer will triage severity, confirm reproducibility, and decide whether the fix should ship as a private patch, a public hotfix, or documented operational guidance.
+
+Security-impacting releases must include verification evidence and explicit customer deployment notes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@
 - `ARCHITECTURE.md`：架构与主流程分层
 - `CHANGELOG.md`：版本变更总表（统一替代旧的 release note / version diff）
 - `DEPLOYMENT.md`：离线部署、打包与交付建议
+- `RELEASE_CHECKLIST.md`：发版前后检查清单，覆盖证据、打包、GitHub release 与回滚
+- `RELEASE_GOVERNANCE.md`：发布门禁与 evidence JSON 口径
 - `TECHNICAL_SPECIFICATION.md`：规格口径与关键实现约束
 
 ## 阅读顺序
@@ -16,6 +18,7 @@
 4. 需要理解程序边界与实现口径时看 `TECHNICAL_SPECIFICATION.md`
 5. 需要部署交付时看 `DEPLOYMENT.md`
 6. 需要回溯最近版本变化时看 `CHANGELOG.md`
+7. 准备公开发版时看 `RELEASE_CHECKLIST.md` 与 `RELEASE_GOVERNANCE.md`
 
 ## 说明
 - `HOW_TO_READ_REPORTS_IN_OB_latest.txt` 与时间快照文件不放在 `docs/`，因为它们是交付给客户/DBA 的数据库侧排障手册。

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,75 @@
+# Release Checklist
+
+Use this checklist before publishing a public release or customer hotfix.
+
+## 1. Freeze Scope
+
+- Confirm the release branch starts from the latest `main`.
+- Record version, branch, commit, and tag candidate.
+- Confirm only intended files are changed with `git status --short`.
+- Confirm OpenSpec is present and validated for any new capability, switch, report, or compatibility rule.
+
+## 2. Verify
+
+Run the minimum local gate:
+
+```bash
+python3 -m py_compile $(git ls-files '*.py')
+git diff --check
+```
+
+For changes touching `schema_diff_reconciler.py` or `run_fixup.py`, record:
+
+- commands executed
+- pass/fail result
+- impact scope
+- skipped validation and reason, if any
+
+For summary/detail/report_db behavior, verify count consistency across:
+
+- main summary
+- split detail files
+- report_db tables
+
+For database semantics, run real Oracle and OceanBase verification. If a release changes `source_db_mode=oceanbase`, include OB-source verification.
+
+## 3. Package
+
+Prefer a complete toolkit zip over partial file replacement.
+
+At minimum, a customer hotfix package must keep these files together:
+
+- `schema_diff_reconciler.py`
+- `run_fixup.py`
+- `diagnostic_bundle.py`
+- `comparator_reliability.py`
+- `config.ini.template.txt`
+- `readme_config.txt`
+- `readme_lite.txt`
+- `README.md`
+- `blacklist_rules.json`
+- `compatibility_registry.json`
+
+Do not include:
+
+- `config.ini`
+- credentials or wallets
+- generated `main_reports/`, `fixup_scripts/`, or local smoke output
+- ad hoc test fixtures unless they are intentionally tracked
+
+## 4. Publish
+
+- Create or update the release tag.
+- Upload the toolkit zip.
+- Upload `SHA256SUMS`.
+- Upload release evidence JSON when available.
+- Include customer deployment notes in the GitHub release body.
+- Do not silently move an existing public tag. Publish a new hotfix or clearly document any correction.
+
+## 5. Post-release
+
+- Merge release documentation back to `main`.
+- Delete merged release branches when no longer needed.
+- Confirm GitHub release assets are downloadable.
+- Confirm the default branch shows the current docs and CI status.
+- Record rollback guidance or residual risk if any validation was intentionally skipped.


### PR DESCRIPTION
## Summary

Adds the public GitHub project governance layer for this repository:

- CI workflow for dependency-free Python compile and diff hygiene checks.
- Dependabot version update configuration for Python and GitHub Actions.
- CODEOWNERS, issue templates, PR template, SECURITY.md, and CODE_OF_CONDUCT.md.
- Release checklist and README badges.

## Validation

Commands executed:

```bash
python3 -m py_compile $(git ls-files '*.py')
git diff --check
git diff --cached --check
```

Results:

- `py_compile`: passed
- diff hygiene: passed
- real DB verification: not applicable, metadata/docs/CI only

## Impact

No runtime code changes. This is repository operations, release hygiene, and public contribution workflow only.
