### PR TITLE
fix: preserve terminal sequence for trigger synonyms

### DIFF
--- a/schema_diff_reconciler.py
+++ b/schema_diff_reconciler.py
@@ -42339,6 +42339,8 @@ def remap_trigger_object_references(
                     tgt_full = terminal_explicit.upper()
                 if not tgt_full and terminal_explicit:
                     tgt_full = terminal_explicit.upper()
+                if not tgt_full:
+                    tgt_full = terminal_u
 
         return (tgt_full or src_full).upper()
 


### PR DESCRIPTION
## Summary

Fixes trigger DDL sequence rewriting when a trigger uses `synonym.NEXTVAL` or `schema.synonym.CURRVAL` and the synonym terminal sequence is not part of the migration mapping.

The previous fallback returned the original synonym reference, for example `APP.SEQ_SYN.NEXTVAL`. Once the synonym terminal has been resolved, the fallback now uses the real terminal sequence, for example `SEQOWNER.MY_SEQ.NEXTVAL`.

## Audit Verdict

The external review finding is valid.

Root cause:

- `_resolve_sequence_target()` resolved the synonym terminal source.
- If the terminal sequence had no `full_object_mapping` entry and no explicit remap rule, `tgt_full` remained empty.
- The final fallback returned `src_full`, which is the synonym reference, not the resolved terminal sequence.

## Validation

Commands executed:

```bash
.venv/bin/python -m unittest test_schema_diff_reconciler.TestSchemaDiffReconcilerPureFunctions.test_remap_trigger_object_references_synonym_sequence_falls_back_to_terminal test_schema_diff_reconciler.TestSchemaDiffReconcilerPureFunctions.test_remap_trigger_object_references_qualified_synonym_sequence_falls_back_to_terminal -v
.venv/bin/python -m unittest test_schema_diff_reconciler.TestSchemaDiffReconcilerPureFunctions.test_remap_trigger_object_references_sequence_fallback_qualifies_source_schema test_schema_diff_reconciler.TestSchemaDiffReconcilerPureFunctions.test_remap_trigger_object_references_public_synonym_sequence_ignores_suffix_collision test_schema_diff_reconciler.TestSchemaDiffReconcilerPureFunctions.test_remap_trigger_object_references_qualified_sequence_prefers_sequence_mapping -v
.venv/bin/python -m unittest test_schema_diff_reconciler.TestSchemaDiffReconcilerPureFunctions -v
python3 -m py_compile $(git ls-files '*.py')
git diff --check
git diff --cached --check
```

Results:

- New local ignored regression cases first failed before the fix, then passed after the fix.
- Existing trigger sequence fallback and mapping regression cases passed.
- `TestSchemaDiffReconcilerPureFunctions`: 819 tests passed.
- Tracked Python compile: passed.
- Diff hygiene: passed.

## Impact

Runtime change is limited to trigger DDL rewriting for sequence references whose synonym terminal is resolved but unmapped. No new report semantics were added in this bugfix.
