### PR TITLE
docs: add openspec for trigger public sequence synonym hotfix

### DIFF
--- a/openspec/changes/update-trigger-public-sequence-synonym-hotfix6/.openspec.yaml
+++ b/openspec/changes/update-trigger-public-sequence-synonym-hotfix6/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/update-trigger-public-sequence-synonym-hotfix6/proposal.md
+++ b/openspec/changes/update-trigger-public-sequence-synonym-hotfix6/proposal.md
@@ -1,0 +1,39 @@
+# Change: Preserve external PUBLIC sequence synonym targets in trigger DDL
+
+## Why
+Customer trigger bodies can call sequences through synonyms, for example
+`seq_syn.NEXTVAL` or `schema.seq_syn.NEXTVAL`.  The existing trigger DDL
+rewrite correctly resolves mapped sequences, but one production edge case was
+still unsafe: a PUBLIC synonym can point to a real sequence outside the managed
+source schema set.  The PUBLIC synonym was pruned from synonym metadata before
+trigger rewrite, or the resolved terminal sequence had no mapping, so the final
+fallback used the trigger schema plus synonym name.  That can compile against a
+wrong object if such an object exists in the target.
+
+OceanBase source metadata also stores PUBLIC synonyms as `__public` on some
+versions.  The same helper metadata path must treat that owner as PUBLIC.
+
+## What Changes
+1. Trigger DDL sequence rewrite keeps helper metadata for PUBLIC synonyms whose
+   terminal object is a local SEQUENCE, even when the terminal owner is outside
+   the managed source schema list.
+2. If a synonym terminal sequence is resolved but has no object mapping and no
+   explicit remap rule, trigger rewrite falls back to the real terminal sequence
+   full name rather than the original synonym reference.
+3. OceanBase source synonym metadata loading treats `OWNER='__public'` as
+   PUBLIC when reading PUBLIC synonym rows.
+4. The helper metadata is scoped to trigger DDL reference resolution only.  It
+   does not expand source object compare/fixup scope or synonym fixup scope.
+
+## Impact
+- Affected specs:
+  - `generate-fixup`
+- Affected code:
+  - `schema_diff_reconciler.py`
+  - `test_schema_diff_reconciler.py` local regression coverage
+- Affected docs/release:
+  - `README.md`
+  - `docs/CHANGELOG.md`
+  - `readme_config.txt`
+  - `readme_lite.txt`
+  - version metadata in release-facing docs/scripts

--- a/openspec/changes/update-trigger-public-sequence-synonym-hotfix6/specs/generate-fixup/spec.md
+++ b/openspec/changes/update-trigger-public-sequence-synonym-hotfix6/specs/generate-fixup/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Trigger sequence references must be schema-qualified in generated DDL
+The system SHALL rewrite unqualified trigger sequence references (`seq_name.NEXTVAL/CURRVAL`) into schema-qualified references in generated trigger DDL.
+
+#### Scenario: Sequence mapping exists
+- **WHEN** trigger SQL contains unqualified `seq_name.NEXTVAL/CURRVAL`
+- **AND** source sequence has a `SEQUENCE` mapping target
+- **THEN** generated trigger DDL uses mapped `schema.sequence.NEXTVAL/CURRVAL`
+
+#### Scenario: Sequence mapping missing
+- **WHEN** trigger SQL contains unqualified `seq_name.NEXTVAL/CURRVAL`
+- **AND** source sequence has no `SEQUENCE` mapping
+- **THEN** generated trigger DDL still schema-qualifies to `source_schema.sequence.NEXTVAL/CURRVAL`
+
+#### Scenario: Explicit remap overrides identity fallback
+- **WHEN** trigger SQL contains unqualified `seq_name.NEXTVAL/CURRVAL`
+- **AND** remap rules explicitly map `SOURCE_SCHEMA.SEQ_NAME` to a target full name
+- **THEN** generated trigger DDL uses the explicit remap target
+
+#### Scenario: Sequence synonym terminal resolution
+- **WHEN** trigger SQL contains unqualified `seq_name.NEXTVAL/CURRVAL`
+- **AND** `seq_name` resolves via private/public synonym to a terminal sequence
+- **THEN** generated trigger DDL resolves terminal sequence first, then applies mapping/remap/fallback rules
+
+#### Scenario: Public synonym terminal outside managed schema
+- **WHEN** trigger SQL contains `seq_syn.NEXTVAL/CURRVAL`
+- **AND** `seq_syn` is a PUBLIC synonym to a local SEQUENCE outside the managed source schema list
+- **AND** the terminal SEQUENCE has no mapping and no explicit remap rule
+- **THEN** generated trigger DDL uses the real terminal `owner.sequence.NEXTVAL/CURRVAL`
+- **AND** the system SHALL NOT treat the trigger owner plus synonym name as the sequence target
+
+#### Scenario: OB source public owner alias
+- **WHEN** OceanBase source synonym metadata stores PUBLIC synonyms with owner `__public`
+- **AND** a trigger sequence reference resolves through that synonym to a local SEQUENCE
+- **THEN** generated trigger DDL treats the synonym owner as PUBLIC and applies terminal sequence rewrite rules
+
+#### Scenario: Trigger helper metadata does not widen compare scope
+- **WHEN** trigger-only PUBLIC sequence synonym metadata is retained for DDL rewrite
+- **THEN** the helper synonym and external terminal sequence are not added to the main compare/fixup object set solely because of that helper metadata
+
+#### Scenario: Already qualified references are left unchanged
+- **WHEN** trigger SQL contains `schema.seq_name.NEXTVAL/CURRVAL`
+- **THEN** rewrite does not duplicate or alter that qualifier by unqualified sequence rewrite rule

--- a/openspec/changes/update-trigger-public-sequence-synonym-hotfix6/tasks.md
+++ b/openspec/changes/update-trigger-public-sequence-synonym-hotfix6/tasks.md
@@ -1,0 +1,21 @@
+## 1. Implementation
+- [x] 1.1 Preserve trigger-only helper metadata for PUBLIC synonyms that resolve to local SEQUENCE objects outside the managed terminal schema list.
+- [x] 1.2 Keep the metadata expansion out of main object compare/fixup scope.
+- [x] 1.3 Normalize OceanBase source PUBLIC synonym owner aliases, including `__public`.
+- [x] 1.4 Preserve the real terminal sequence owner as fallback when synonym resolution succeeds but mapping/remap is absent.
+
+## 2. Tests
+- [x] 2.1 Add focused regression coverage for PUBLIC synonym -> external SEQUENCE trigger rewrite.
+- [x] 2.2 Run focused trigger/synonym regression tests.
+- [x] 2.3 Run pure-function regression suite.
+- [x] 2.4 Run `python3 -m py_compile $(git ls-files '*.py')`.
+
+## 3. Real DB verification
+- [x] 3.1 Oracle source: create PUBLIC synonym to external SEQUENCE outside managed schema and verify generated trigger rewrite uses the real sequence owner.
+- [x] 3.2 OceanBase source: create PUBLIC/`__public` synonym to external SEQUENCE and verify generated trigger rewrite uses the real sequence owner.
+- [x] 3.3 Run Oracle -> OB smoke compare with TRIGGER/SEQUENCE enabled and verify the report is generated with version `V0.9.9.6-hotfix6`.
+
+## 4. Release
+- [x] 4.1 Update hotfix6 release documentation and version metadata.
+- [x] 4.2 Build release package and verify SHA256 sums.
+- [x] 4.3 Merge PR and publish GitHub release `v0.9.9.6-hotfix6`.


### PR DESCRIPTION
## Summary
- add OpenSpec change update-trigger-public-sequence-synonym-hotfix6
- document the hotfix6 trigger sequence synonym root cause, scope, and delivered verification
- add generate-fixup spec delta for PUBLIC synonym -> external SEQUENCE trigger rewrite and OB __public owner handling

## Verification
- PASS: openspec validate update-trigger-public-sequence-synonym-hotfix6 --strict
- PASS: pre-commit detect-secrets during commit
- PASS: push pytest hook

## Notes
- Documentation/spec-only change; no runtime code changes.
- Existing v0.9.9.6-hotfix6 release assets are unchanged.